### PR TITLE
feat!: production-ready upgrade with bug fixes, features, tests, and CI

### DIFF
--- a/.github/changelog/release-changelog-builder.json
+++ b/.github/changelog/release-changelog-builder.json
@@ -1,0 +1,37 @@
+{
+  "template": "# Changelog\n\n#{{CHANGELOG}}\n\n#{{UNCATEGORIZED}}",
+  "categories": [
+    {"title": "💥 Breaking Changes", "labels": ["breaking"]},
+    {"title": "✨ Features", "labels": ["feat", "feature"]},
+    {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
+    {"title": "⚡ Performance", "labels": ["perf"]},
+    {"title": "♻️ Refactoring", "labels": ["refactor"]},
+    {"title": "📝 Documentation", "labels": ["docs"]},
+    {"title": "🧪 Tests", "labels": ["test"]},
+    {"title": "🤖 CI / Build", "labels": ["ci", "build"]},
+    {"title": "📦 Dependencies", "labels": ["dependency", "deps"]},
+    {"title": "🧹 Chores", "labels": ["chore"]},
+    {"title": "🔒 Security", "labels": ["security"]},
+    {"title": "↩️ Reverts", "labels": ["revert"]}
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(build|chore|ci|deps|docs|feat|fix|perf|refactor|revert|security|style|test)(\\([\\w\\-\\.]+\\))?(!)?: .+",
+      "on_property": "title",
+      "target": "$1",
+      "flags": "i"
+    },
+    {
+      "pattern": "BREAKING CHANGE",
+      "on_property": "title",
+      "target": "breaking"
+    }
+  ],
+  "sort": {
+    "on_property": "mergedAt",
+    "order": "ASC"
+  },
+  "max_tags_to_fetch": 200,
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: ['**']
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -26,9 +27,31 @@ env:
   TERM: xterm-256color
 
 jobs:
-  test:
-    name: Lint, Compile & Test
+  format:
+    name: Check Formatting
     runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - name: Cache Coursier
+        uses: coursier/cache-action@v6
+      - name: Scalafmt Check
+        run: sbt scalafmtCheckAll scalafmtSbtCheck
+
+  test:
+    name: Test (Java ${{ matrix.java }})
+    runs-on: ubuntu-24.04
+    needs: [format]
+    strategy:
+      matrix:
+        java: ['17', '21']
     services:
       rabbitmq:
         image: rabbitmq:3.13.7-management-alpine
@@ -46,11 +69,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Java (Temurin 17) with sbt cache
+      - name: Setup Java (Temurin ${{ matrix.java }})
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Cache Coursier
@@ -62,15 +85,16 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
-          restore-keys: sbt-${{ runner.os }}-
-      - name: Check Formatting
-        run: sbt scalafmtCheckAll scalafmtSbtCheck
+          key: sbt-${{ runner.os }}-java${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-java${{ matrix.java }}-
       - name: Compile
         run: sbt clean compile
-      - name: Tests (including Gatling example)
-        run: sbt coverage "Gatling / testOnly org.galaxio.gatling.amqp.examples.AmqpGatlingTest" test coverageReport coverageOff
+      - name: Unit Tests with Coverage
+        run: sbt coverage test coverageReport coverageOff
+      - name: Integration Tests (Gatling)
+        run: sbt "Gatling / testOnly org.galaxio.gatling.amqp.examples.AmqpGatlingTest"
       - name: Upload coverage reports to Codecov
+        if: matrix.java == '17'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
@@ -207,29 +231,7 @@ jobs:
           mode: "COMMIT"
           fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
           toTag:   ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
-          configurationJson: |
-            {
-              "template": "# Changelog\n\n#{{CHANGELOG}}",
-              "categories": [
-                {"title": "✨ Features", "labels": ["feat", "feature"]},
-                {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
-                {"title": "📝 Documentation", "labels": ["docs"]},
-                {"title": "⚡ Performance Improvements", "labels": ["perf"]},
-                {"title": "♻️ Refactoring", "labels": ["refactor"]},
-                {"title": "🧪 Tests", "labels": ["test"]},
-                {"title": "🧹 Chores", "labels": ["chore"]},
-                {"title": "📦 Dependencies", "labels": ["dependency"]},
-                {"title": "🚨 Breaking Changes", "labels": ["breaking"]},
-                {"title": "🤖 CI / Build", "labels": ["ci"]}
-              ],
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ]
-            }
+          configuration: ".github/changelog/release-changelog-builder.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -1,59 +1,372 @@
-# Gatling AMQP Plugin 
+# Gatling AMQP Plugin
 
 [![Build](https://github.com/galax-io/gatling-amqp-plugin/workflows/Continuous%20Integration/badge.svg)](https://github.com/galax-io/gatling-amqp-plugin/actions/workflows/ci.yml)
-[![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/gatling-amqp-plugin_2.13.svg?color=success)](https://search.maven.org/search?q=org.galaxio.gatling-amqp-plugin) 
+[![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/gatling-amqp-plugin_2.13.svg?color=success)](https://search.maven.org/search?q=org.galaxio.gatling-amqp-plugin)
+[![codecov](https://codecov.io/github/galax-io/gatling-amqp-plugin/coverage.svg?branch=main)](https://codecov.io/github/galax-io/gatling-amqp-plugin?branch=main)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
-[![codecov.io](https://codecov.io/github/galax-io/gatling-amqp-plugin/coverage.svg?branch=master)](https://codecov.io/github/galax-io/gatling-amqp-plugin?branch=master)
 
-Plugin for support performance testing with AMQP in Gatling(3.9.x)
+AMQP protocol plugin for [Gatling](https://gatling.io/) load testing framework. Supports RabbitMQ with publish, request-reply, and consume patterns.
 
-# Usage
+## Table of Contents
 
-## Getting Started
-Plugin is currently available for Scala 2.13, Java 17, Kotlin.
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Protocol Configuration](#protocol-configuration)
+  - [Connection Factory](#connection-factory)
+  - [Advanced Connection Settings](#advanced-connection-settings)
+  - [Protocol Options](#protocol-options)
+  - [Queue and Exchange Declarations](#queue-and-exchange-declarations)
+- [Actions](#actions)
+  - [Publish](#publish)
+  - [Request-Reply](#request-reply)
+  - [Consume](#consume)
+- [Message Properties](#message-properties)
+- [Checks](#checks)
+- [Silent Mode](#silent-mode)
+- [Publisher Confirms](#publisher-confirms)
+- [Examples](#examples)
+- [Contributing](#contributing)
+- [License](#license)
 
-You may add plugin as dependency in project with your tests. 
+## Installation
 
-### Scala
+**Scala** (build.sbt):
+```scala
+libraryDependencies += "org.galaxio" %% "gatling-amqp-plugin" % "<version>" % Test
+```
 
-Write this to your build.sbt: 
-
-``` scala
-libraryDependencies += "org.galaxio" %% "gatling-amqp-plugin" % <version> % Test
-``` 
-
-### Java
-
-Write this to your dependencies block in build.gradle:
-
-```java
+**Java / Kotlin** (build.gradle):
+```groovy
 gatling "org.galaxio:gatling-amqp-plugin_2.13:<version>"
 ```
 
-### Kotlin
-
-Write this to your dependencies block in build.gradle:
-
-```kotlin
-gatling("org.galaxio:gatling-amqp-plugin_2.13:<version>")
+**Maven**:
+```xml
+<dependency>
+  <groupId>org.galaxio</groupId>
+  <artifactId>gatling-amqp-plugin_2.13</artifactId>
+  <version>${version}</version>
+  <scope>test</scope>
+</dependency>
 ```
 
-## Example Scenarios
+Requires Scala 2.13, Java 17+, Gatling 3.11+.
 
-### Scala 
+## Quick Start
 
-* Example scenario for [publishing](src/test/scala/org/galaxio/gatling/amqp/examples/PublishExample.scala)
-* Example scenario for [Publish And Reply](src/test/scala/org/galaxio/gatling/amqp/examples/RequestReplyExample.scala)
-* Example scenario for [Publish and Reply on different message-brokers](src/test/scala/org/galaxio/gatling/amqp/examples/RequestReplyTwoBrokerExample.scala)
+### Scala
+
+```scala
+import org.galaxio.gatling.amqp.Predef._
+import io.gatling.core.Predef._
+
+class AmqpSimulation extends Simulation {
+  val amqpConf = amqp
+    .connectionFactory(
+      rabbitmq
+        .host("localhost")
+        .port(5672)
+        .username("guest")
+        .password("guest")
+        .vhost("/")
+    )
+    .usePersistentDeliveryMode
+    .matchByMessageId
+
+  val scn = scenario("AMQP Publish")
+    .exec(
+      amqp("publish").publish
+        .queueExchange("test-queue")
+        .textMessage("""{"msg": "hello"}""")
+        .contentType("application/json")
+    )
+
+  setUp(scn.inject(atOnceUsers(1))).protocols(amqpConf)
+}
+```
 
 ### Java
 
-* Example scenario for [publishing](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/PublishExample.java)
-* Example scenario for [Publish And Reply](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyExample.java)
-* Example scenario for [Publish and Reply on different message-brokers](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyTwoBrokerExample.java)
+```java
+import static org.galaxio.gatling.amqp.javaapi.AmqpDsl.*;
+import static io.gatling.javaapi.core.CoreDsl.*;
+
+public class AmqpSimulation extends Simulation {
+  var amqpConf = amqp()
+    .connectionFactory(
+      rabbitmq().host("localhost").port(5672).username("guest").password("guest").build()
+    )
+    .usePersistentDeliveryMode()
+    .matchByMessageId();
+
+  var scn = scenario("AMQP Publish")
+    .exec(
+      amqp("publish").publish()
+        .queueExchange("test-queue")
+        .textMessage("{\"msg\": \"hello\"}")
+        .contentType("application/json")
+    );
+
+  { setUp(scn.injectOpen(atOnceUsers(1)).protocols(amqpConf)); }
+}
+```
+
+## Protocol Configuration
+
+### Connection Factory
+
+```scala
+val cf = rabbitmq
+  .host("localhost")
+  .port(5672)
+  .username("guest")
+  .password("guest")
+  .vhost("/")
+```
+
+### Advanced Connection Settings
+
+```scala
+val cf = rabbitmq
+  .host("localhost")
+  .port(5672)
+  .username("guest")
+  .password("guest")
+  .automaticRecovery(true)          // auto-reconnect on failure (default: true)
+  .networkRecoveryInterval(5000)     // reconnect interval in ms
+  .topologyRecovery(true)            // recover queues/exchanges (default: true)
+  .connectionTimeout(10000)          // TCP connection timeout in ms
+  .requestedHeartbeat(60)            // heartbeat interval in seconds
+  .requestedChannelMax(0)            // max channels per connection (0 = unlimited)
+  .useSslProtocol()                  // enable SSL with default protocol
+  // or .useSslProtocol("TLSv1.2")  // enable SSL with specific protocol
+```
+
+### Protocol Options
+
+```scala
+val amqpConf = amqp
+  .connectionFactory(publishCf)                  // single connection factory
+  // or
+  .connectionFactory(publishCf, replyCf)         // separate publish/reply connections
+
+  .usePersistentDeliveryMode                     // delivery mode 2
+  .useNonPersistentDeliveryMode                  // delivery mode 1 (default)
+
+  .matchByMessageId                              // match replies by messageId (default)
+  .matchByCorrelationId                          // match replies by correlationId
+  .matchByMessage(msg => msg.messageId)          // custom match extraction
+
+  .replyTimeout(30000)                           // reply timeout in ms
+  .consumerThreadsCount(4)                       // consumer threads per pool
+  .channelPoolSize(32)                           // max pooled channels (default: 16)
+  .usePublisherConfirms                          // enable publisher confirms
+
+  .responseTransform(msg => msg)                 // transform reply messages before checks
+```
+
+### Queue and Exchange Declarations
+
+```scala
+val amqpConf = amqp
+  .connectionFactory(cf)
+  .declare(queue("test-queue", durable = true, exclusive = false, autoDelete = false))
+  .declare(exchange("test-exchange", BuiltinExchangeType.TOPIC, durable = true))
+  .bindQueue(
+    queue("test-queue", durable = true),
+    exchange("test-exchange", BuiltinExchangeType.TOPIC),
+    "routing.key"
+  )
+```
+
+## Actions
+
+### Publish
+
+Publish messages to exchanges or queues:
+
+```scala
+// Queue exchange
+amqp("publish").publish
+  .queueExchange("my-queue")
+  .textMessage("""{"data": "value"}""")
+
+// Topic exchange
+amqp("publish").publish
+  .topicExchange("my-exchange", "routing.key")
+  .textMessage("""{"data": "value"}""")
+
+// Direct exchange
+amqp("publish").publish
+  .directExchange("my-exchange", "routing.key")
+  .bytesMessage(myBytes)
+
+// With EL expressions
+amqp("publish-#{id}").publish
+  .queueExchange("queue-#{name}")
+  .textMessage("""{"id": "#{id}"}""")
+```
+
+### Request-Reply
+
+Publish a message and wait for a reply:
+
+```scala
+amqp("request-reply").requestReply
+  .topicExchange("request-exchange", "request.key")
+  .replyExchange("reply-exchange", "reply.key")
+  .textMessage("""{"query": "data"}""")
+  .messageId("#{msgId}")
+  .check(jsonPath("$.result").is("ok"))
+```
+
+Multi-broker setup (publish to one broker, consume reply from another):
+
+```scala
+val amqpConf = amqp
+  .connectionFactory(publisherCf, replyConsumerCf)
+  .matchByCorrelationId
+  .replyTimeout(10000)
+```
+
+### Consume
+
+Pull a single message from a queue:
+
+```scala
+amqp("consume").consume
+  .queue("my-queue")
+  .timeout(5000)
+  .check(bodyString.is("expected"))
+```
+
+## Message Properties
+
+All message properties support Gatling Expression Language:
+
+```scala
+amqp("publish").publish
+  .queueExchange("my-queue")
+  .textMessage("hello")
+  .messageId("#{msgId}")
+  .correlationId("#{corrId}")
+  .contentType("application/json")
+  .contentEncoding("UTF-8")
+  .priority(5)
+  .replyTo("reply-queue")
+  .expiration("60000")
+  .amqpType("my.type")
+  .userId("guest")
+  .appId("my-app")
+  .header("X-Custom", "value")
+  .headers("X-One" -> "1", "X-Two" -> "2")
+```
+
+## Checks
+
+Checks are supported on request-reply and consume actions:
+
+```scala
+import org.galaxio.gatling.amqp.Predef._
+
+// JSON checks
+.check(jsonPath("$.status").is("ok"))
+.check(jsonPath("$.items[*].id").findAll.saveAs("ids"))
+.check(jmesPath("status").is("ok"))
+
+// XML checks
+.check(xpath("//status").is("ok"))
+
+// Body checks
+.check(bodyString.is("expected"))
+.check(bodyBytes.exists)
+.check(substring("success").exists)
+
+// Response code
+.check(responseCode.notIn("500", "503"))
+
+// Simple custom check
+.check(simpleCheck(msg => msg.payload.nonEmpty))
+
+// Conditional check
+.check(checkIf("#{useCheck}")(jsonPath("$.data").exists))
+```
+
+## Silent Mode
+
+Mark requests as silent to suppress statistics logging. Useful for setup/teardown operations:
+
+```scala
+amqp("setup-publish").publish
+  .queueExchange("setup-queue")
+  .textMessage("init")
+  .silent
+
+amqp("setup-rpc").requestReply
+  .queueExchange("setup-queue")
+  .replyExchange("reply-queue")
+  .textMessage("init")
+  .silent
+
+amqp("drain").consume
+  .queue("my-queue")
+  .silent
+```
+
+## Publisher Confirms
+
+Enable publisher confirms for guaranteed delivery. The channel calls `waitForConfirmsOrDie` after each publish:
+
+```scala
+val amqpConf = amqp
+  .connectionFactory(cf)
+  .usePublisherConfirms
+```
+
+**Note:** Publisher confirms add latency per publish. Use when delivery guarantee is more important than throughput.
+
+## Examples
+
+### Scala
+
+- [Publish](src/test/scala/org/galaxio/gatling/amqp/examples/PublishExample.scala)
+- [Request-Reply](src/test/scala/org/galaxio/gatling/amqp/examples/RequestReplyExample.scala)
+- [Two Brokers](src/test/scala/org/galaxio/gatling/amqp/examples/RequestReplyTwoBrokerExample.scala)
+- [Custom Matching](src/test/scala/org/galaxio/gatling/amqp/examples/RequestReplyWithOwnMatchingExample.scala)
+
+### Java
+
+- [Publish](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/PublishExample.java)
+- [Request-Reply](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyExample.java)
+- [Two Brokers](src/test/java/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyTwoBrokerExample.java)
 
 ### Kotlin
 
-* Example scenario for [publishing](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/PublishExample.kt)
-* Example scenario for [Publish And Reply](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyExample.kt)
-* Example scenario for [Publish and Reply on different message-brokers](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyTwoBrokerExample.kt)
+- [Publish](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/PublishExample.kt)
+- [Request-Reply](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyExample.kt)
+- [Two Brokers](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyTwoBrokerExample.kt)
+
+## Contributing
+
+```bash
+# Build
+sbt compile
+
+# Run unit tests
+sbt test
+
+# Run integration tests (requires RabbitMQ)
+docker-compose up -d
+sbt "Gatling / testOnly org.galaxio.gatling.amqp.examples.AmqpGatlingTest"
+
+# Check formatting
+sbt scalafmtCheckAll
+
+# Format code
+sbt scalafmtAll
+```
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
     Gatling / publishArtifact   := false,
     GatlingIt / publishArtifact := false,
     libraryDependencies ++= gatling ++ gatlingCore,
-    libraryDependencies ++= Seq(rabbitmq, commonsPool, fastUUID),
+    libraryDependencies ++= Seq(rabbitmq, commonsPool, fastUUID, scalaTest),
     scalacOptions ++= Seq(
       "-encoding",
       "utf8", // Option and arguments on same line

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,4 +17,6 @@ object Dependencies {
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.13.1"
   lazy val fastUUID    = "com.eatthepath"     % "fast-uuid"     % "0.2.0"
 
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19" % Test
+
 }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/AmqpProtocolBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/AmqpProtocolBuilder.java
@@ -9,7 +9,6 @@ import scala.Function1;
 import java.util.Map;
 
 public class AmqpProtocolBuilder implements ProtocolBuilder{
-    public AmqpProtocolBuilder usePersistentDeliveryMode;
     private org.galaxio.gatling.amqp.protocol.AmqpProtocolBuilder wrapped;
 
     public AmqpProtocolBuilder(org.galaxio.gatling.amqp.protocol.AmqpProtocolBuilder wrapped) {
@@ -32,7 +31,7 @@ public class AmqpProtocolBuilder implements ProtocolBuilder{
     }
 
     public AmqpProtocolBuilder matchByCorrelationId() {
-        this.wrapped = wrapped.matchByMessageId();
+        this.wrapped = wrapped.matchByCorrelationId();
         return this;
     }
 
@@ -53,6 +52,16 @@ public class AmqpProtocolBuilder implements ProtocolBuilder{
 
     public AmqpProtocolBuilder consumerThreadsCount(Integer threadCount) {
         this.wrapped = wrapped.consumerThreadsCount(threadCount);
+        return this;
+    }
+
+    public AmqpProtocolBuilder channelPoolSize(Integer size) {
+        this.wrapped = wrapped.channelPoolSize(size);
+        return this;
+    }
+
+    public AmqpProtocolBuilder usePublisherConfirms() {
+        this.wrapped = wrapped.usePublisherConfirms();
         return this;
     }
 

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/RabbitMQConnectionFactoryBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/RabbitMQConnectionFactoryBuilder.java
@@ -29,6 +29,46 @@ public class RabbitMQConnectionFactoryBuilder{
         return this;
     }
 
+    public RabbitMQConnectionFactoryBuilder automaticRecovery(Boolean enabled){
+        this.wrapped = wrapped.automaticRecovery(enabled);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder networkRecoveryInterval(Long millis){
+        this.wrapped = wrapped.networkRecoveryInterval(millis);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder topologyRecovery(Boolean enabled){
+        this.wrapped = wrapped.topologyRecovery(enabled);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder connectionTimeout(Integer millis){
+        this.wrapped = wrapped.connectionTimeout(millis);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder requestedHeartbeat(Integer seconds){
+        this.wrapped = wrapped.requestedHeartbeat(seconds);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder requestedChannelMax(Integer max){
+        this.wrapped = wrapped.requestedChannelMax(max);
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder useSslProtocol(){
+        this.wrapped = wrapped.useSslProtocol();
+        return this;
+    }
+
+    public RabbitMQConnectionFactoryBuilder useSslProtocol(String protocol){
+        this.wrapped = wrapped.useSslProtocol(protocol);
+        return this;
+    }
+
     public ConnectionFactory build(){
         return wrapped.build();
     }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/RabbitMQConnectionFactoryBuilderBase.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/RabbitMQConnectionFactoryBuilderBase.java
@@ -1,9 +1,20 @@
 package org.galaxio.gatling.amqp.javaapi.protocol;
 
 import scala.Option;
+import scala.None$;
 
 public class RabbitMQConnectionFactoryBuilderBase {
+    @SuppressWarnings("unchecked")
+    private static <T> Option<T> none() {
+        return (Option<T>) None$.MODULE$;
+    }
+
     public RabbitMQConnectionFactoryBuilder host(String host) {
-        return new RabbitMQConnectionFactoryBuilder(org.galaxio.gatling.amqp.protocol.RabbitMQConnectionFactoryBuilder.apply(Option.apply(host), null, null,null,null));
+        return new RabbitMQConnectionFactoryBuilder(
+            org.galaxio.gatling.amqp.protocol.RabbitMQConnectionFactoryBuilder.apply(
+                Option.apply(host), none(), none(), none(), none(),
+                true, none(), true, none(), none(), none(), false, none()
+            )
+        );
     }
 }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/AmqpDslBuilderBase.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/AmqpDslBuilderBase.java
@@ -1,5 +1,7 @@
 package org.galaxio.gatling.amqp.javaapi.request;
 
+import static io.gatling.javaapi.core.internal.Expressions.*;
+
 public final class AmqpDslBuilderBase {
     private final org.galaxio.gatling.amqp.request.AmqpDslBuilderBase wrapped;
 
@@ -12,5 +14,10 @@ public final class AmqpDslBuilderBase {
     }
     public RequestReplyDslBuilderExchange requestReply(){
         return new RequestReplyDslBuilderExchange(wrapped.requestReply(io.gatling.core.Predef.configuration()));
+    }
+    public ConsumeDslBuilder consume(String queueName){
+        return new ConsumeDslBuilder(
+            wrapped.consume(io.gatling.core.Predef.configuration()).queue(toStringExpression(queueName))
+        );
     }
 }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/ConsumeDslBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/ConsumeDslBuilder.java
@@ -1,0 +1,38 @@
+package org.galaxio.gatling.amqp.javaapi.request;
+
+import io.gatling.javaapi.core.ActionBuilder;
+import org.galaxio.gatling.amqp.javaapi.check.AmqpChecks;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ConsumeDslBuilder implements ActionBuilder {
+    private org.galaxio.gatling.amqp.request.ConsumeDslBuilder wrapped;
+
+    public ConsumeDslBuilder(org.galaxio.gatling.amqp.request.ConsumeDslBuilder wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    public ConsumeDslBuilder timeout(Long millis) {
+        this.wrapped = wrapped.timeout(millis);
+        return this;
+    }
+
+    public ConsumeDslBuilder check(Object... checks) {
+        return check(Arrays.asList(checks));
+    }
+
+    public ConsumeDslBuilder check(List<Object> checks) {
+        this.wrapped = wrapped.check(AmqpChecks.toScalaChecks(checks));
+        return this;
+    }
+
+    public ConsumeDslBuilder silent() {
+        this.wrapped = wrapped.silent();
+        return this;
+    }
+
+    public io.gatling.core.action.builder.ActionBuilder asScala() {
+        return wrapped.build();
+    }
+}

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/PublishDslBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/PublishDslBuilder.java
@@ -90,6 +90,11 @@ public class PublishDslBuilder implements ActionBuilder {
         return this;
     }
 
+    public PublishDslBuilder silent() {
+        this.wrapped = wrapped.silent();
+        return this;
+    }
+
     public io.gatling.core.action.builder.ActionBuilder asScala(){
         return wrapped.build();
     }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilder.java
@@ -101,6 +101,11 @@ public class RequestReplyDslBuilder implements ActionBuilder {
         return this;
     }
 
+    public RequestReplyDslBuilder silent() {
+        this.wrapped = wrapped.silent();
+        return this;
+    }
+
     public io.gatling.core.action.builder.ActionBuilder asScala(){
         return wrapped.build();
     }

--- a/src/main/scala/org/galaxio/gatling/amqp/AmqpDsl.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/AmqpDsl.scala
@@ -12,7 +12,7 @@ import org.galaxio.gatling.amqp.protocol.{
   AmqpProtocolBuilderBase,
   RabbitMQConnectionFactoryBuilder,
 }
-import org.galaxio.gatling.amqp.request.{AmqpDslBuilderBase, PublishDslBuilder, RequestReplyDslBuilder}
+import org.galaxio.gatling.amqp.request.{AmqpDslBuilderBase, ConsumeDslBuilder, PublishDslBuilder, RequestReplyDslBuilder}
 
 trait AmqpDsl extends AmqpCheckSupport {
   def amqp(implicit configuration: GatlingConfiguration): AmqpProtocolBuilderBase.type = AmqpProtocolBuilderBase
@@ -48,6 +48,9 @@ trait AmqpDsl extends AmqpCheckSupport {
   implicit def amqpPublishDslBuilder2ActionBuilder(builder: PublishDslBuilder): ActionBuilder = builder.build()
 
   implicit def amqpRequestReplyDslBuilder2ActionBuilder(builder: RequestReplyDslBuilder): ActionBuilder =
+    builder.build()
+
+  implicit def amqpConsumeDslBuilder2ActionBuilder(builder: ConsumeDslBuilder): ActionBuilder =
     builder.build()
 
   implicit def rabbitMQ2ConnectionFactory(builder: RabbitMQConnectionFactoryBuilder): ConnectionFactory = builder.build

--- a/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
@@ -1,0 +1,107 @@
+package org.galaxio.gatling.amqp.action
+
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.util.Clock
+import io.gatling.commons.validation.{Failure, Validation}
+import io.gatling.core.action.{Action, RequestAction}
+import io.gatling.core.check.Check
+import io.gatling.core.controller.throttle.Throttler
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.util.NameGen
+import org.galaxio.gatling.amqp.protocol.AmqpComponents
+import org.galaxio.gatling.amqp.request.{AmqpProtocolMessage, ConsumeAttributes}
+
+class Consume(
+    attributes: ConsumeAttributes,
+    components: AmqpComponents,
+    val statsEngine: StatsEngine,
+    val clock: Clock,
+    val next: Action,
+    throttler: Option[Throttler],
+) extends RequestAction with AmqpLogging with NameGen {
+  override val name: String = genName("amqpConsume")
+
+  override val requestName: Expression[String] = attributes.requestName
+
+  override def sendRequest(session: Session): Validation[Unit] =
+    for {
+      reqName   <- requestName(session)
+      queueName <- attributes.queueName(session)
+    } yield throttler
+      .fold(consumeAndLog(reqName, queueName, session))(
+        _.throttle(session.scenario, () => consumeAndLog(reqName, queueName, session)),
+      )
+
+  private def consumeAndLog(requestNameString: String, queueName: String, session: Session): Unit = {
+    val now = clock.nowMillis
+    try {
+      val pool     = components.connectionPublishPool
+      val channel  = pool.channel
+      val response =
+        try channel.basicGet(queueName, true)
+        finally pool.returnChannel(channel)
+
+      if (response == null) {
+        if (!attributes.silent)
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            requestNameString,
+            now,
+            clock.nowMillis,
+            KO,
+            None,
+            Some("No message available in queue"),
+          )
+        next ! session.markAsFailed
+      } else {
+        val message             = AmqpProtocolMessage(response.getProps, response.getBody)
+        val (newSession, error) = Check.check(message, session, attributes.checks)
+        error match {
+          case Some(Failure(errorMessage)) =>
+            if (!attributes.silent)
+              statsEngine.logResponse(
+                newSession.scenario,
+                newSession.groups,
+                requestNameString,
+                now,
+                clock.nowMillis,
+                KO,
+                message.responseCode,
+                Some(errorMessage),
+              )
+            next ! newSession.markAsFailed
+          case _                           =>
+            if (!attributes.silent)
+              statsEngine.logResponse(
+                newSession.scenario,
+                newSession.groups,
+                requestNameString,
+                now,
+                clock.nowMillis,
+                OK,
+                message.responseCode,
+                None,
+              )
+            next ! newSession
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        logger.error(e.getMessage, e)
+        if (!attributes.silent)
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            requestNameString,
+            now,
+            clock.nowMillis,
+            KO,
+            Some("500"),
+            Some(e.getMessage),
+          )
+        next ! session.markAsFailed
+    }
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/amqp/action/ConsumeBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/ConsumeBuilder.scala
@@ -1,0 +1,29 @@
+package org.galaxio.gatling.amqp.action
+
+import org.galaxio.gatling.amqp.protocol.{AmqpComponents, AmqpProtocol}
+import org.galaxio.gatling.amqp.request.ConsumeAttributes
+import io.gatling.core.action.Action
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.protocol.ProtocolComponentsRegistry
+import io.gatling.core.structure.ScenarioContext
+
+case class ConsumeBuilder(attributes: ConsumeAttributes, configuration: GatlingConfiguration) extends ActionBuilder {
+
+  private def components(protocolComponentsRegistry: ProtocolComponentsRegistry): AmqpComponents =
+    protocolComponentsRegistry.components(AmqpProtocol.amqpProtocolKey)
+
+  override def build(ctx: ScenarioContext, next: Action): Action = {
+    import ctx._
+    val amqpComponents = components(protocolComponentsRegistry)
+
+    new Consume(
+      attributes,
+      amqpComponents,
+      coreComponents.statsEngine,
+      coreComponents.clock,
+      next,
+      coreComponents.throttler,
+    )
+  }
+}

--- a/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
@@ -34,20 +34,22 @@ class Publish(
       if (logger.underlying.isDebugEnabled) {
         logMessage(s"Message sent user=${session.userId} AMQPMessageID=${msg.messageId}", msg)
       }
-      statsEngine.logResponse(session.scenario, session.groups, requestNameString, now, clock.nowMillis, OK, None, None)
+      if (!attributes.silent)
+        statsEngine.logResponse(session.scenario, session.groups, requestNameString, now, clock.nowMillis, OK, None, None)
     } catch {
       case e: Throwable =>
         logger.error(e.getMessage, e)
-        statsEngine.logResponse(
-          session.scenario,
-          session.groups,
-          requestNameString,
-          now,
-          clock.nowMillis,
-          KO,
-          Some("500"),
-          Some(e.getMessage),
-        )
+        if (!attributes.silent)
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            requestNameString,
+            now,
+            clock.nowMillis,
+            KO,
+            Some("500"),
+            Some(e.getMessage),
+          )
     }
     next ! session
   }

--- a/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
@@ -52,20 +52,30 @@ class RequestReply(
         if (logger.underlying.isDebugEnabled) {
           logMessage(s"Message sent user=${session.userId} AMQPMessageID=${msg.messageId}", msg)
         }
-        tracker.track(id, clock.nowMillis, replyTimeout, attributes.checks, session, next, requestNameString)
+        tracker.track(
+          id,
+          clock.nowMillis,
+          replyTimeout,
+          attributes.checks,
+          session,
+          next,
+          requestNameString,
+          attributes.silent,
+        )
       } catch {
         case e: Throwable =>
           logger.error(e.getMessage, e)
-          statsEngine.logResponse(
-            session.scenario,
-            session.groups,
-            requestNameString,
-            now,
-            clock.nowMillis,
-            KO,
-            Some("500"),
-            Some(e.getMessage),
-          )
+          if (!attributes.silent)
+            statsEngine.logResponse(
+              session.scenario,
+              session.groups,
+              requestNameString,
+              now,
+              clock.nowMillis,
+              KO,
+              Some("500"),
+              Some(e.getMessage),
+            )
       }
     }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpChannelFactory.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpChannelFactory.scala
@@ -4,8 +4,13 @@ import com.rabbitmq.client.{Channel, Connection}
 import org.apache.commons.pool2.impl.DefaultPooledObject
 import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
 
-class AmqpChannelFactory(rabbitmqConnection: Connection) extends BasePooledObjectFactory[Channel] {
-  override def create(): Channel = rabbitmqConnection.createChannel()
+class AmqpChannelFactory(rabbitmqConnection: Connection, publisherConfirms: Boolean = false)
+    extends BasePooledObjectFactory[Channel] {
+  override def create(): Channel = {
+    val ch = rabbitmqConnection.createChannel()
+    if (publisherConfirms) ch.confirmSelect()
+    ch
+  }
 
   override def wrap(obj: Channel): PooledObject[Channel] = new DefaultPooledObject[Channel](obj)
 

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpConnectionPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpConnectionPool.scala
@@ -6,14 +6,20 @@ import com.rabbitmq.client.{Channel, Connection, ConnectionFactory}
 import org.apache.commons.pool2.ObjectPool
 import org.apache.commons.pool2.impl.{GenericObjectPool, GenericObjectPoolConfig}
 
-class AmqpConnectionPool(factory: ConnectionFactory, consumerThreadsCount: Int) {
+class AmqpConnectionPool(
+    factory: ConnectionFactory,
+    consumerThreadsCount: Int,
+    channelPoolSize: Int = 16,
+    publisherConfirms: Boolean = false,
+) {
 
   private val connection: Connection = factory.newConnection(Executors.newFixedThreadPool(consumerThreadsCount))
 
   private val poolConfig = new GenericObjectPoolConfig[Channel]()
-  poolConfig.setMaxTotal(16)
+  poolConfig.setMaxTotal(channelPoolSize)
 
-  private val channelPool: ObjectPool[Channel] = new GenericObjectPool[Channel](new AmqpChannelFactory(connection))
+  private val channelPool: ObjectPool[Channel] =
+    new GenericObjectPool[Channel](new AmqpChannelFactory(connection, publisherConfirms), poolConfig)
 
   def createConsumerChannel: Channel = connection.createChannel()
 

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTracker.scala
@@ -16,6 +16,7 @@ class AmqpMessageTracker(actor: ActorRef) {
       session: Session,
       next: Action,
       requestName: String,
+      silent: Boolean = false,
   ): Unit =
     actor ! MessagePublished(
       matchId,
@@ -25,5 +26,6 @@ class AmqpMessageTracker(actor: ActorRef) {
       session,
       next,
       requestName,
+      silent,
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
@@ -29,6 +29,7 @@ object AmqpMessageTrackerActor {
       session: Session,
       next: Action,
       requestName: String,
+      silent: Boolean = false,
   )
 
   case class MessageConsumed(
@@ -68,22 +69,22 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
       requestName: String,
       responseCode: Option[String],
       message: Option[String],
+      silent: Boolean = false,
   ): Unit = {
-    statsEngine.logResponse(
-      session.scenario,
-      session.groups,
-      requestName,
-      sent,
-      received,
-      status,
-      responseCode,
-      message,
-    )
+    if (!silent)
+      statsEngine.logResponse(
+        session.scenario,
+        session.groups,
+        requestName,
+        sent,
+        received,
+        status,
+        responseCode,
+        message,
+      )
     next ! session.logGroupRequestTimings(sent, received)
   }
 
-  /** Processes a matched message
-    */
   private def processMessage(
       session: Session,
       sent: Long,
@@ -92,6 +93,7 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
       message: AmqpProtocolMessage,
       next: Action,
       requestName: String,
+      silent: Boolean,
   ): Unit = {
     val (newSession, error) = Check.check(message, session, checks)
     error match {
@@ -105,9 +107,10 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
           requestName,
           message.responseCode,
           Some(errorMessage),
+          silent,
         )
       case _                           =>
-        executeNext(newSession, sent, received, OK, next, requestName, message.responseCode, message.responseCode)
+        executeNext(newSession, sent, received, OK, next, requestName, message.responseCode, message.responseCode, silent)
     }
   }
 
@@ -126,8 +129,8 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
     // message was received; publish stats and remove from the map
     case MessageConsumed(matchId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
-      sentMessages.remove(matchId).foreach { case MessagePublished(_, sent, _, checks, session, next, requestName) =>
-        processMessage(session, sent, received, checks, message, next, requestName)
+      sentMessages.remove(matchId).foreach { case MessagePublished(_, sent, _, checks, session, next, requestName, silent) =>
+        processMessage(session, sent, received, checks, message, next, requestName, silent)
       }
 
     case TimeoutScan =>
@@ -139,7 +142,7 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
         }
       }
 
-      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName) <- timedOutMessages) {
+      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent) <- timedOutMessages) {
         sentMessages.remove(matchId)
         executeNext(
           session.markAsFailed,
@@ -150,6 +153,7 @@ class AmqpMessageTrackerActor(statsEngine: StatsEngine, clock: Clock) extends Ac
           requestName,
           None,
           Some(s"Reply timeout after $receivedTimeout ms"),
+          silent,
         )
       }
       timedOutMessages.clear()

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpPublisher.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpPublisher.scala
@@ -5,6 +5,9 @@ import org.galaxio.gatling.amqp.protocol.AmqpComponents
 import org.galaxio.gatling.amqp.request._
 
 class AmqpPublisher(destination: AmqpExchange, components: AmqpComponents) extends WithAmqpChannel {
+
+  private val awaitConfirm = components.protocol.publisherConfirms
+
   def publish(message: AmqpProtocolMessage, session: Session): Unit = {
 
     destination match {
@@ -12,18 +15,27 @@ class AmqpPublisher(destination: AmqpExchange, components: AmqpComponents) exten
         for {
           exName <- name(session)
           exKey  <- routingKey(session)
-        } withChannel(channel => channel.basicPublish(exName, exKey, message.amqpProperties, message.payload))
+        } withChannel { channel =>
+          channel.basicPublish(exName, exKey, message.amqpProperties, message.payload)
+          if (awaitConfirm) channel.waitForConfirmsOrDie(5000)
+        }
 
       case AmqpQueueExchange(name, _) =>
         name(session).foreach(qName =>
-          withChannel(channel => channel.basicPublish("", qName, message.amqpProperties, message.payload)),
+          withChannel { channel =>
+            channel.basicPublish("", qName, message.amqpProperties, message.payload)
+            if (awaitConfirm) channel.waitForConfirmsOrDie(5000)
+          },
         )
 
       case AmqpTopicExchange(name, routingKey, _) =>
         for {
           exName <- name(session)
           exKey  <- routingKey(session)
-        } withChannel(channel => channel.basicPublish(exName, exKey, message.amqpProperties, message.payload))
+        } withChannel { channel =>
+          channel.basicPublish(exName, exKey, message.amqpProperties, message.payload)
+          if (awaitConfirm) channel.waitForConfirmsOrDie(5000)
+        }
     }
   }
 

--- a/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
@@ -1,7 +1,7 @@
 package org.galaxio.gatling.amqp.client
 
 import akka.actor.ActorSystem
-import com.rabbitmq.client.Delivery
+import com.rabbitmq.client.{Channel, Delivery}
 import io.gatling.commons.util.Clock
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.stats.StatsEngine
@@ -12,6 +12,8 @@ import org.galaxio.gatling.amqp.protocol.AmqpMessageMatcher
 import org.galaxio.gatling.amqp.request.AmqpProtocolMessage
 
 import java.util.concurrent.ConcurrentHashMap
+import scala.collection.mutable
+import scala.util.Try
 
 class TrackerPool(
     pool: AmqpConnectionPool,
@@ -21,7 +23,8 @@ class TrackerPool(
     configuration: GatlingConfiguration,
 ) extends AmqpLogging with NameGen {
 
-  private val trackers = new ConcurrentHashMap[String, AmqpMessageTracker]
+  private val trackers        = new ConcurrentHashMap[String, AmqpMessageTracker]
+  private val consumerEntries = mutable.ArrayBuffer.empty[(Channel, String)]
 
   def tracker(
       sourceQueue: String,
@@ -37,7 +40,7 @@ class TrackerPool(
 
         for (_ <- 1 to listenerThreadCount) {
           val consumerChannel = pool.createConsumerChannel
-          consumerChannel.basicConsume(
+          val consumerTag     = consumerChannel.basicConsume(
             sourceQueue,
             true,
             (_: String, message: Delivery) => {
@@ -56,9 +59,21 @@ class TrackerPool(
             },
             (_: String) => (),
           )
+          consumerEntries.synchronized {
+            consumerEntries += ((consumerChannel, consumerTag))
+          }
         }
 
         new AmqpMessageTracker(actor)
       },
     )
+
+  def close(): Unit =
+    consumerEntries.synchronized {
+      consumerEntries.foreach { case (channel, tag) =>
+        Try(channel.basicCancel(tag))
+        Try(channel.close())
+      }
+      consumerEntries.clear()
+    }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/client/WithAmqpChannel.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/WithAmqpChannel.scala
@@ -1,14 +1,23 @@
 package org.galaxio.gatling.amqp.client
 
-import com.rabbitmq.client.Channel
+import com.rabbitmq.client.{AlreadyClosedException, Channel, ShutdownSignalException}
 
 trait WithAmqpChannel {
   protected val pool: AmqpConnectionPool
   def withChannel[T](channelAction: Channel => T): T = {
-    val ch     = pool.channel
-    val result = channelAction(ch)
-    pool.returnChannel(ch)
-    result
+    val ch = pool.channel
+    try {
+      val result = channelAction(ch)
+      pool.returnChannel(ch)
+      result
+    } catch {
+      case e @ (_: AlreadyClosedException | _: ShutdownSignalException) =>
+        pool.invalidate(ch)
+        throw e
+      case e: Throwable                                                 =>
+        pool.returnChannel(ch)
+        throw e
+    }
   }
 
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpComponents.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpComponents.scala
@@ -13,6 +13,5 @@ case class AmqpComponents(
 ) extends ProtocolComponents {
   override def onStart: Session => Session = Session.Identity
 
-  override def onExit: Session => Unit = ProtocolComponents.NoopOnExit
-
+  override def onExit: Session => Unit = _ => trackerPool.close()
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
@@ -25,7 +25,12 @@ object AmqpProtocol {
     private def getOrCreateConnectionPublishPool(protocol: AmqpProtocol) = {
       if (connectionPublishPoolRef.get() == null) {
         connectionPublishPoolRef.lazySet(
-          new AmqpConnectionPool(protocol.connectionFactory, protocol.consumersThreadCount),
+          new AmqpConnectionPool(
+            protocol.connectionFactory,
+            protocol.consumersThreadCount,
+            protocol.channelPoolSize,
+            protocol.publisherConfirms,
+          ),
         )
       }
       connectionPublishPoolRef.get()
@@ -34,7 +39,12 @@ object AmqpProtocol {
     private def getOrCreateConnectionReplyPool(protocol: AmqpProtocol) = {
       if (connectionReplyPoolRef.get() == null) {
         connectionReplyPoolRef.lazySet(
-          new AmqpConnectionPool(protocol.replyConnectionFactory, protocol.consumersThreadCount),
+          new AmqpConnectionPool(
+            protocol.replyConnectionFactory,
+            protocol.consumersThreadCount,
+            protocol.channelPoolSize,
+            publisherConfirms = false,
+          ),
         )
       }
       connectionReplyPoolRef.get()
@@ -92,6 +102,8 @@ case class AmqpProtocol(
     messageMatcher: AmqpMessageMatcher,
     responseTransformer: Option[AmqpProtocolMessage => AmqpProtocolMessage],
     initActions: AmqpChannelInitActions,
+    channelPoolSize: Int = 16,
+    publisherConfirms: Boolean = false,
 ) extends Protocol {
   type Components = AmqpComponents
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilder.scala
@@ -12,6 +12,8 @@ case class AmqpProtocolBuilder(
     replyTimeout: Option[Long] = None,
     responseTransformer: Option[AmqpProtocolMessage => AmqpProtocolMessage] = None,
     initActions: AmqpChannelInitActions = Nil,
+    channelPoolSize: Int = 16,
+    publisherConfirms: Boolean = false,
 ) {
 
   def usePersistentDeliveryMode: AmqpProtocolBuilder    = copy(deliveryMode = Persistent())
@@ -34,6 +36,8 @@ case class AmqpProtocolBuilder(
 
   def replyTimeout(timeout: Long): AmqpProtocolBuilder            = copy(replyTimeout = Some(timeout))
   def consumerThreadsCount(threadCount: Int): AmqpProtocolBuilder = copy(consumerThreadsCount = threadCount)
+  def channelPoolSize(size: Int): AmqpProtocolBuilder             = copy(channelPoolSize = size)
+  def usePublisherConfirms: AmqpProtocolBuilder                   = copy(publisherConfirms = true)
 
   def declare(q: AmqpQueue): AmqpProtocolBuilder    = this.copy(initActions = this.initActions :+ QueueDeclare(q))
   def declare(e: AmqpExchange): AmqpProtocolBuilder = this.copy(initActions = this.initActions :+ ExchangeDeclare(e))
@@ -56,5 +60,7 @@ case class AmqpProtocolBuilder(
       messageMatcher,
       responseTransformer,
       initActions,
+      channelPoolSize,
+      publisherConfirms,
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/RabbitMQConnectionFactoryBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/RabbitMQConnectionFactoryBuilder.scala
@@ -8,6 +8,14 @@ case class RabbitMQConnectionFactoryBuilder(
     username: Option[String] = None,
     password: Option[String] = None,
     virtualHost: Option[String] = None,
+    automaticRecovery: Boolean = true,
+    networkRecoveryInterval: Option[Long] = None,
+    topologyRecovery: Boolean = true,
+    connectionTimeout: Option[Int] = None,
+    requestedHeartbeat: Option[Int] = None,
+    requestedChannelMax: Option[Int] = None,
+    useSsl: Boolean = false,
+    sslProtocol: Option[String] = None,
 ) {
 
   def username(rabbitUsername: String): RabbitMQConnectionFactoryBuilder =
@@ -21,6 +29,30 @@ case class RabbitMQConnectionFactoryBuilder(
   def vhost(rabbitVHost: String): RabbitMQConnectionFactoryBuilder =
     this.copy(virtualHost = Some(rabbitVHost))
 
+  def automaticRecovery(enabled: Boolean): RabbitMQConnectionFactoryBuilder =
+    this.copy(automaticRecovery = enabled)
+
+  def networkRecoveryInterval(millis: Long): RabbitMQConnectionFactoryBuilder =
+    this.copy(networkRecoveryInterval = Some(millis))
+
+  def topologyRecovery(enabled: Boolean): RabbitMQConnectionFactoryBuilder =
+    this.copy(topologyRecovery = enabled)
+
+  def connectionTimeout(millis: Int): RabbitMQConnectionFactoryBuilder =
+    this.copy(connectionTimeout = Some(millis))
+
+  def requestedHeartbeat(seconds: Int): RabbitMQConnectionFactoryBuilder =
+    this.copy(requestedHeartbeat = Some(seconds))
+
+  def requestedChannelMax(max: Int): RabbitMQConnectionFactoryBuilder =
+    this.copy(requestedChannelMax = Some(max))
+
+  def useSslProtocol(): RabbitMQConnectionFactoryBuilder =
+    this.copy(useSsl = true)
+
+  def useSslProtocol(protocol: String): RabbitMQConnectionFactoryBuilder =
+    this.copy(useSsl = true, sslProtocol = Some(protocol))
+
   def build: ConnectionFactory = {
     val cf = new ConnectionFactory()
 
@@ -30,7 +62,15 @@ case class RabbitMQConnectionFactoryBuilder(
     password.foreach(cf.setPassword)
     virtualHost.foreach(cf.setVirtualHost)
 
-    cf
+    cf.setAutomaticRecoveryEnabled(automaticRecovery)
+    cf.setTopologyRecoveryEnabled(topologyRecovery)
+    networkRecoveryInterval.foreach(cf.setNetworkRecoveryInterval)
+    connectionTimeout.foreach(cf.setConnectionTimeout)
+    requestedHeartbeat.foreach(cf.setRequestedHeartbeat)
+    requestedChannelMax.foreach(cf.setRequestedChannelMax)
 
+    if (useSsl) sslProtocol.fold(cf.useSslProtocol())(cf.useSslProtocol)
+
+    cf
   }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/AmqpDslBuilderBase.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/AmqpDslBuilderBase.scala
@@ -8,4 +8,6 @@ case class AmqpDslBuilderBase(requestName: Expression[String]) {
     PublishDslBuilderExchange(requestName, configuration)
   def requestReply(implicit configuration: GatlingConfiguration): RequestReplyDslBuilderExchange =
     RequestReplyDslBuilderExchange(requestName, configuration)
+  def consume(implicit configuration: GatlingConfiguration): ConsumeDslBuilderQueue              =
+    ConsumeDslBuilderQueue(requestName, configuration)
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/AmqpMessageProperties.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/AmqpMessageProperties.scala
@@ -42,7 +42,7 @@ object AmqpMessageProperties {
     contentType(s, bp, bp.contentType)
     contentEncoding(s, bp, bp.contentEncoding)
     deliveryMode(s, bp, i => bp.deliveryMode(i))
-    priority(s, bp, i => bp.deliveryMode(i))
+    priority(s, bp, i => bp.priority(i))
     correlationId(s, bp, bp.correlationId)
     replyTo(s, bp, bp.replyTo)
     expiration(s, bp, bp.expiration)

--- a/src/main/scala/org/galaxio/gatling/amqp/request/ConsumeAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/ConsumeAttributes.scala
@@ -3,12 +3,10 @@ package org.galaxio.gatling.amqp.request
 import io.gatling.core.session.Expression
 import org.galaxio.gatling.amqp.AmqpCheck
 
-case class AmqpAttributes(
+case class ConsumeAttributes(
     requestName: Expression[String],
-    destination: AmqpExchange,
-    selector: Option[String],
-    message: AmqpMessage,
-    messageProperties: AmqpMessageProperties = AmqpMessageProperties(),
+    queueName: Expression[String],
+    timeout: Long = 5000,
     checks: List[AmqpCheck] = Nil,
     silent: Boolean = false,
 )

--- a/src/main/scala/org/galaxio/gatling/amqp/request/ConsumeDslBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/ConsumeDslBuilder.scala
@@ -1,0 +1,23 @@
+package org.galaxio.gatling.amqp.request
+
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.Expression
+import org.galaxio.gatling.amqp.AmqpCheck
+import org.galaxio.gatling.amqp.action.ConsumeBuilder
+import io.gatling.core.config.GatlingConfiguration
+
+case class ConsumeDslBuilderQueue(requestName: Expression[String], configuration: GatlingConfiguration) {
+  def queue(name: Expression[String]): ConsumeDslBuilder =
+    ConsumeDslBuilder(ConsumeAttributes(requestName, name), configuration)
+}
+
+case class ConsumeDslBuilder(attributes: ConsumeAttributes, configuration: GatlingConfiguration) {
+  def timeout(millis: Long): ConsumeDslBuilder = copy(attributes = attributes.copy(timeout = millis))
+
+  def check(checks: AmqpCheck*): ConsumeDslBuilder =
+    copy(attributes = attributes.copy(checks = attributes.checks ::: checks.toList))
+
+  def silent: ConsumeDslBuilder = copy(attributes = attributes.copy(silent = true))
+
+  def build(): ActionBuilder = ConsumeBuilder(attributes, configuration)
+}

--- a/src/main/scala/org/galaxio/gatling/amqp/request/PublishDslBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/PublishDslBuilder.scala
@@ -49,5 +49,7 @@ case class PublishDslBuilder(attributes: AmqpAttributes, factory: AmqpAttributes
   def headers(hs: (String, Expression[String])*): PublishDslBuilder =
     hs.foldLeft(this) { case (rb, (k, v)) => rb.header(k, v) }
 
+  def silent: PublishDslBuilder = this.modify(_.attributes.silent).setTo(true)
+
   def build(): ActionBuilder = factory(attributes)
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilder.scala
@@ -53,5 +53,7 @@ case class RequestReplyDslBuilder(attributes: AmqpAttributes, factory: AmqpAttri
   def check(checks: AmqpCheck*): RequestReplyDslBuilder =
     this.modify(_.attributes.checks).using(_ ::: checks.toList)
 
+  def silent: RequestReplyDslBuilder = this.modify(_.attributes.silent).setTo(true)
+
   def build(): ActionBuilder = factory(attributes)
 }

--- a/src/test/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilderSpec.scala
@@ -1,0 +1,159 @@
+package org.galaxio.gatling.amqp.protocol
+
+import com.rabbitmq.client.{BuiltinExchangeType, ConnectionFactory}
+import org.galaxio.gatling.amqp.request.AmqpProtocolMessage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AmqpProtocolBuilderSpec extends AnyFlatSpec with Matchers {
+
+  private val cf      = new ConnectionFactory()
+  private val replyCf = new ConnectionFactory()
+
+  private def defaultBuilder: AmqpProtocolBuilder = AmqpProtocolBuilder(cf, replyCf)
+
+  "AmqpProtocolBuilder" should "have correct default values" in {
+    val builder = defaultBuilder
+
+    builder.deliveryMode shouldBe a[NonPersistent]
+    builder.messageMatcher shouldBe MessageIdMessageMatcher
+    builder.consumerThreadsCount shouldBe 1
+    builder.replyTimeout shouldBe None
+    builder.responseTransformer shouldBe None
+    builder.initActions shouldBe Nil
+  }
+
+  it should "set persistent delivery mode" in {
+    val builder = defaultBuilder.usePersistentDeliveryMode
+
+    builder.deliveryMode shouldBe a[Persistent]
+    builder.deliveryMode.mode shouldBe 2
+  }
+
+  it should "set non-persistent delivery mode" in {
+    val builder = defaultBuilder.usePersistentDeliveryMode.useNonPersistentDeliveryMode
+
+    builder.deliveryMode shouldBe a[NonPersistent]
+    builder.deliveryMode.mode shouldBe 1
+  }
+
+  it should "set MessageIdMessageMatcher via matchByMessageId" in {
+    val builder = defaultBuilder.matchByCorrelationId.matchByMessageId
+
+    builder.messageMatcher shouldBe MessageIdMessageMatcher
+  }
+
+  it should "set CorrelationIdMessageMatcher via matchByCorrelationId" in {
+    val builder = defaultBuilder.matchByCorrelationId
+
+    builder.messageMatcher shouldBe CorrelationIdMessageMatcher
+  }
+
+  it should "set custom AmqpProtocolMessageMatcher via matchByMessage" in {
+    val extractor: AmqpProtocolMessage => String = msg => msg.correlationId
+    val builder                                  = defaultBuilder.matchByMessage(extractor)
+
+    builder.messageMatcher shouldBe a[AmqpProtocolMessageMatcher]
+  }
+
+  it should "set reply timeout" in {
+    val builder = defaultBuilder.replyTimeout(5000L)
+
+    builder.replyTimeout shouldBe Some(5000L)
+  }
+
+  it should "set consumer threads count" in {
+    val builder = defaultBuilder.consumerThreadsCount(4)
+
+    builder.consumerThreadsCount shouldBe 4
+  }
+
+  it should "set response transformer" in {
+    val transformer: AmqpProtocolMessage => AmqpProtocolMessage = identity
+    val builder                                                 = defaultBuilder.responseTransform(transformer)
+
+    builder.responseTransformer shouldBe defined
+  }
+
+  it should "append QueueDeclare to initActions when declaring a queue" in {
+    val q       = AmqpQueue("test-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.declare(q)
+
+    builder.initActions should have size 1
+    builder.initActions.head shouldBe QueueDeclare(q)
+  }
+
+  it should "append ExchangeDeclare to initActions when declaring an exchange" in {
+    val e       = AmqpExchange("test-exchange", BuiltinExchangeType.TOPIC, durable = true, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.declare(e)
+
+    builder.initActions should have size 1
+    builder.initActions.head shouldBe ExchangeDeclare(e)
+  }
+
+  it should "append BindQueue to initActions when binding a queue" in {
+    val q       = AmqpQueue("test-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val e       = AmqpExchange("test-exchange", BuiltinExchangeType.TOPIC, durable = true, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.bindQueue(q, e, "routing.key")
+
+    builder.initActions should have size 1
+    builder.initActions.head shouldBe BindQueue("test-queue", "test-exchange", "routing.key", Map.empty)
+  }
+
+  it should "accumulate multiple initActions in order" in {
+    val q = AmqpQueue("q1", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val e = AmqpExchange("e1", BuiltinExchangeType.DIRECT, durable = true, autoDelete = false, arguments = Map.empty)
+
+    val builder = defaultBuilder
+      .declare(q)
+      .declare(e)
+      .bindQueue(q, e, "rk")
+
+    builder.initActions should have size 3
+    builder.initActions(0) shouldBe QueueDeclare(q)
+    builder.initActions(1) shouldBe ExchangeDeclare(e)
+    builder.initActions(2) shouldBe BindQueue("q1", "e1", "rk", Map.empty)
+  }
+
+  it should "build an AmqpProtocol with all settings preserved" in {
+    val q = AmqpQueue("q1", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+
+    val protocol = defaultBuilder.usePersistentDeliveryMode.matchByCorrelationId
+      .replyTimeout(10000L)
+      .consumerThreadsCount(2)
+      .declare(q)
+      .build
+
+    protocol.connectionFactory shouldBe cf
+    protocol.replyConnectionFactory shouldBe replyCf
+    protocol.deliveryMode shouldBe a[Persistent]
+    protocol.messageMatcher shouldBe CorrelationIdMessageMatcher
+    protocol.replyTimeout shouldBe Some(10000L)
+    protocol.consumersThreadCount shouldBe 2
+    protocol.initActions should have size 1
+  }
+
+  it should "be created from AmqpProtocolBuilderBase with single ConnectionFactory" in {
+    val builder = AmqpProtocolBuilderBase.connectionFactory(cf)
+
+    builder.requestConnectionFactory shouldBe cf
+    builder.replyConnectionFactory shouldBe cf
+  }
+
+  it should "be created from AmqpProtocolBuilderBase with separate ConnectionFactories" in {
+    val builder = AmqpProtocolBuilderBase.connectionFactory(cf, replyCf)
+
+    builder.requestConnectionFactory shouldBe cf
+    builder.replyConnectionFactory shouldBe replyCf
+  }
+
+  it should "pass bindQueue args to BindQueue" in {
+    val q    = AmqpQueue("q1", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val e    = AmqpExchange("e1", BuiltinExchangeType.FANOUT, durable = true, autoDelete = false, arguments = Map.empty)
+    val args = Map("x-match" -> ("all": Any))
+
+    val builder = defaultBuilder.bindQueue(q, e, "rk", args)
+
+    builder.initActions.head shouldBe BindQueue("q1", "e1", "rk", args)
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/protocol/MessageMatcherSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/protocol/MessageMatcherSpec.scala
@@ -1,0 +1,119 @@
+package org.galaxio.gatling.amqp.protocol
+
+import com.rabbitmq.client.AMQP
+import org.galaxio.gatling.amqp.request.AmqpProtocolMessage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MessageMatcherSpec extends AnyFlatSpec with Matchers {
+
+  private def mkMsg(
+      messageId: String = null,
+      correlationId: String = null,
+  ): AmqpProtocolMessage =
+    AmqpProtocolMessage(
+      new AMQP.BasicProperties.Builder()
+        .messageId(messageId)
+        .correlationId(correlationId)
+        .build(),
+      Array.emptyByteArray,
+    )
+
+  // --- MessageIdMessageMatcher ---
+
+  "MessageIdMessageMatcher" should "return messageId as requestMatchId" in {
+    val msg = mkMsg(messageId = "msg-123")
+
+    MessageIdMessageMatcher.requestMatchId(msg) shouldBe "msg-123"
+  }
+
+  it should "return messageId as responseMatchId" in {
+    val msg = mkMsg(messageId = "msg-456")
+
+    MessageIdMessageMatcher.responseMatchId(msg) shouldBe "msg-456"
+  }
+
+  it should "return message unchanged from prepareRequest" in {
+    val msg    = mkMsg(messageId = "msg-789")
+    val result = MessageIdMessageMatcher.prepareRequest(msg)
+
+    result shouldBe theSameInstanceAs(msg)
+  }
+
+  // --- CorrelationIdMessageMatcher ---
+
+  "CorrelationIdMessageMatcher" should "add a correlationId via prepareRequest" in {
+    val msg    = mkMsg(messageId = "m1")
+    val result = CorrelationIdMessageMatcher.prepareRequest(msg)
+
+    result.correlationId should not be null
+    result.correlationId should not be empty
+  }
+
+  it should "generate a UUID-format correlationId" in {
+    val msg    = mkMsg()
+    val result = CorrelationIdMessageMatcher.prepareRequest(msg)
+
+    // UUID format: 8-4-4-4-12 hex chars
+    result.correlationId should fullyMatch regex """[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"""
+  }
+
+  it should "return correlationId as requestMatchId" in {
+    val msg = mkMsg(correlationId = "corr-abc")
+
+    CorrelationIdMessageMatcher.requestMatchId(msg) shouldBe "corr-abc"
+  }
+
+  it should "return correlationId as responseMatchId" in {
+    val msg = mkMsg(correlationId = "corr-def")
+
+    CorrelationIdMessageMatcher.responseMatchId(msg) shouldBe "corr-def"
+  }
+
+  it should "not modify the original message in prepareRequest" in {
+    val original = mkMsg(messageId = "m1", correlationId = null)
+    val prepared = CorrelationIdMessageMatcher.prepareRequest(original)
+
+    original.correlationId shouldBe null
+    prepared.correlationId should not be null
+  }
+
+  // --- AmqpProtocolMessageMatcher ---
+
+  "AmqpProtocolMessageMatcher" should "use custom extractor for requestMatchId" in {
+    val extractor = (msg: AmqpProtocolMessage) => s"custom-${msg.messageId}"
+    val matcher   = AmqpProtocolMessageMatcher(extractor)
+    val msg       = mkMsg(messageId = "m1")
+
+    matcher.requestMatchId(msg) shouldBe "custom-m1"
+  }
+
+  it should "use custom extractor for responseMatchId" in {
+    val extractor = (msg: AmqpProtocolMessage) => s"resp-${msg.correlationId}"
+    val matcher   = AmqpProtocolMessageMatcher(extractor)
+    val msg       = mkMsg(correlationId = "c1")
+
+    matcher.responseMatchId(msg) shouldBe "resp-c1"
+  }
+
+  it should "return message unchanged from prepareRequest (default trait behavior)" in {
+    val extractor = (msg: AmqpProtocolMessage) => msg.messageId
+    val matcher   = AmqpProtocolMessageMatcher(extractor)
+    val msg       = mkMsg(messageId = "m1")
+    val result    = matcher.prepareRequest(msg)
+
+    result shouldBe theSameInstanceAs(msg)
+  }
+
+  it should "work with payload-based extractor" in {
+    val extractor = (msg: AmqpProtocolMessage) => new String(msg.payload)
+    val matcher   = AmqpProtocolMessageMatcher(extractor)
+    val msg       = AmqpProtocolMessage(
+      new AMQP.BasicProperties.Builder().build(),
+      "my-routing-key".getBytes,
+    )
+
+    matcher.requestMatchId(msg) shouldBe "my-routing-key"
+    matcher.responseMatchId(msg) shouldBe "my-routing-key"
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/protocol/RabbitMQConnectionFactoryBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/protocol/RabbitMQConnectionFactoryBuilderSpec.scala
@@ -1,0 +1,112 @@
+package org.galaxio.gatling.amqp.protocol
+
+import com.rabbitmq.client.ConnectionFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RabbitMQConnectionFactoryBuilderSpec extends AnyFlatSpec with Matchers {
+
+  "RabbitMQConnectionFactoryBuilder" should "produce a ConnectionFactory with default settings when no options set" in {
+    val builder = RabbitMQConnectionFactoryBuilder()
+    val cf      = builder.build
+
+    cf shouldBe a[ConnectionFactory]
+    cf.getHost shouldBe ConnectionFactory.DEFAULT_HOST
+    cf.getPort shouldBe ConnectionFactory.DEFAULT_AMQP_PORT
+    cf.getUsername shouldBe ConnectionFactory.DEFAULT_USER
+    cf.getPassword shouldBe ConnectionFactory.DEFAULT_PASS
+    cf.getVirtualHost shouldBe ConnectionFactory.DEFAULT_VHOST
+  }
+
+  it should "set the host when host is provided" in {
+    val cf = RabbitMQConnectionFactoryBuilder(host = Some("my-rabbit-host")).build
+
+    cf.getHost shouldBe "my-rabbit-host"
+  }
+
+  it should "set the port when port is provided" in {
+    val cf = RabbitMQConnectionFactoryBuilder(port = Some(15672)).build
+
+    cf.getPort shouldBe 15672
+  }
+
+  it should "set the username when username is provided" in {
+    val cf = RabbitMQConnectionFactoryBuilder().username("testuser").build
+
+    cf.getUsername shouldBe "testuser"
+  }
+
+  it should "set the password when password is provided" in {
+    val cf = RabbitMQConnectionFactoryBuilder().password("secret").build
+
+    cf.getPassword shouldBe "secret"
+  }
+
+  it should "set the virtual host when vhost is provided" in {
+    val cf = RabbitMQConnectionFactoryBuilder().vhost("/my-vhost").build
+
+    cf.getVirtualHost shouldBe "/my-vhost"
+  }
+
+  it should "set multiple properties together" in {
+    val cf = RabbitMQConnectionFactoryBuilder(host = Some("broker.example.com"))
+      .port(5673)
+      .username("admin")
+      .password("admin-pass")
+      .vhost("/production")
+      .build
+
+    cf.getHost shouldBe "broker.example.com"
+    cf.getPort shouldBe 5673
+    cf.getUsername shouldBe "admin"
+    cf.getPassword shouldBe "admin-pass"
+    cf.getVirtualHost shouldBe "/production"
+  }
+
+  it should "be immutable - builder methods return new instances" in {
+    val original = RabbitMQConnectionFactoryBuilder()
+    val modified = original.username("changed")
+
+    original.username shouldBe None
+    modified.username shouldBe Some("changed")
+    original should not be theSameInstanceAs(modified)
+  }
+
+  it should "be created via RabbitMQConnectionFactoryBuilderBase.host" in {
+    val builder = RabbitMQConnectionFactoryBuilderBase.host("rabbit-server")
+
+    builder.host shouldBe Some("rabbit-server")
+  }
+
+  it should "be created via RabbitMQConnectionFactoryBuilderBase.default with no options" in {
+    val builder = RabbitMQConnectionFactoryBuilderBase.default
+
+    builder.host shouldBe None
+    builder.port shouldBe None
+    builder.username shouldBe None
+    builder.password shouldBe None
+    builder.virtualHost shouldBe None
+  }
+
+  it should "not modify the ConnectionFactory defaults when optional fields are None" in {
+    val defaultCf = new ConnectionFactory()
+    val builtCf   = RabbitMQConnectionFactoryBuilder().build
+
+    builtCf.getHost shouldBe defaultCf.getHost
+    builtCf.getPort shouldBe defaultCf.getPort
+    builtCf.getUsername shouldBe defaultCf.getUsername
+    builtCf.getPassword shouldBe defaultCf.getPassword
+    builtCf.getVirtualHost shouldBe defaultCf.getVirtualHost
+  }
+
+  it should "allow chaining multiple builder method calls" in {
+    val builder = RabbitMQConnectionFactoryBuilder()
+      .username("user1")
+      .password("pass1")
+      .vhost("/test")
+
+    builder.username shouldBe Some("user1")
+    builder.password shouldBe Some("pass1")
+    builder.virtualHost shouldBe Some("/test")
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/request/AmqpMessagePropertiesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/AmqpMessagePropertiesSpec.scala
@@ -1,0 +1,190 @@
+package org.galaxio.gatling.amqp.request
+
+import io.gatling.commons.stats.OK
+import io.gatling.commons.validation._
+import io.gatling.core.session.Session
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AmqpMessagePropertiesSpec extends AnyFlatSpec with Matchers {
+
+  private val session = Session(
+    scenario = "test",
+    userId = 0L,
+    attributes = Map.empty,
+    baseStatus = OK,
+    blockStack = Nil,
+    onExit = Session.NothingOnExit,
+    eventLoop = null,
+  )
+
+  "AmqpMessageProperties.toBasicProperties" should "produce BasicProperties with all null fields when empty" in {
+    val props  = AmqpMessageProperties()
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    val bp = result.toOption.get
+    bp.getContentType shouldBe null
+    bp.getContentEncoding shouldBe null
+    bp.getDeliveryMode shouldBe null
+    bp.getPriority shouldBe null
+    bp.getCorrelationId shouldBe null
+    bp.getReplyTo shouldBe null
+    bp.getExpiration shouldBe null
+    bp.getMessageId shouldBe null
+    bp.getTimestamp shouldBe null
+    bp.getType shouldBe null
+    bp.getUserId shouldBe null
+    bp.getAppId shouldBe null
+    bp.getClusterId shouldBe null
+    // With empty headers map, the builder sets an empty Java map (not null)
+    bp.getHeaders shouldBe empty
+  }
+
+  it should "set contentType correctly" in {
+    val props  = AmqpMessageProperties(contentType = Some((_: Session) => "application/json".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getContentType shouldBe "application/json"
+  }
+
+  it should "set contentEncoding correctly" in {
+    val props  = AmqpMessageProperties(contentEncoding = Some((_: Session) => "utf-8".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getContentEncoding shouldBe "utf-8"
+  }
+
+  it should "set deliveryMode correctly" in {
+    val props  = AmqpMessageProperties(deliveryMode = Some((_: Session) => 2.success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getDeliveryMode shouldBe 2
+  }
+
+  it should "set priority correctly (not deliveryMode)" in {
+    val props  = AmqpMessageProperties(priority = Some((_: Session) => 5.success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    val bp = result.toOption.get
+    bp.getPriority shouldBe 5
+    bp.getDeliveryMode shouldBe null
+  }
+
+  it should "set both deliveryMode and priority independently" in {
+    val props  = AmqpMessageProperties(
+      deliveryMode = Some((_: Session) => 2.success),
+      priority = Some((_: Session) => 5.success),
+    )
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    val bp = result.toOption.get
+    bp.getDeliveryMode shouldBe 2
+    bp.getPriority shouldBe 5
+  }
+
+  it should "set correlationId correctly" in {
+    val props  = AmqpMessageProperties(correlationId = Some((_: Session) => "corr-123".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getCorrelationId shouldBe "corr-123"
+  }
+
+  it should "set replyTo correctly" in {
+    val props  = AmqpMessageProperties(replyTo = Some((_: Session) => "reply-queue".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getReplyTo shouldBe "reply-queue"
+  }
+
+  it should "set expiration correctly" in {
+    val props  = AmqpMessageProperties(expiration = Some((_: Session) => "60000".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getExpiration shouldBe "60000"
+  }
+
+  it should "set messageId correctly" in {
+    val props  = AmqpMessageProperties(messageId = Some((_: Session) => "msg-456".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getMessageId shouldBe "msg-456"
+  }
+
+  it should "resolve and set headers" in {
+    val headers: Map[String, io.gatling.core.session.Expression[AnyRef]] = Map(
+      "x-custom-header" -> ((_: Session) => ("header-value": AnyRef).success),
+      "x-another"       -> ((_: Session) => ("another-value": AnyRef).success),
+    )
+    val props                                                            = AmqpMessageProperties(headers = headers)
+    val result                                                           = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    val h = result.toOption.get.getHeaders
+    h should not be null
+    h.get("x-custom-header") shouldBe "header-value"
+    h.get("x-another") shouldBe "another-value"
+  }
+
+  it should "set multiple properties together" in {
+    val props  = AmqpMessageProperties(
+      contentType = Some((_: Session) => "text/plain".success),
+      contentEncoding = Some((_: Session) => "utf-8".success),
+      correlationId = Some((_: Session) => "corr-789".success),
+      messageId = Some((_: Session) => "msg-012".success),
+      replyTo = Some((_: Session) => "reply-q".success),
+      expiration = Some((_: Session) => "30000".success),
+    )
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    val bp = result.toOption.get
+    bp.getContentType shouldBe "text/plain"
+    bp.getContentEncoding shouldBe "utf-8"
+    bp.getCorrelationId shouldBe "corr-789"
+    bp.getMessageId shouldBe "msg-012"
+    bp.getReplyTo shouldBe "reply-q"
+    bp.getExpiration shouldBe "30000"
+  }
+
+  it should "set type property correctly" in {
+    val props  = AmqpMessageProperties(`type` = Some((_: Session) => "my-type".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getType shouldBe "my-type"
+  }
+
+  it should "set userId correctly" in {
+    val props  = AmqpMessageProperties(userId = Some((_: Session) => "user1".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getUserId shouldBe "user1"
+  }
+
+  it should "set appId correctly" in {
+    val props  = AmqpMessageProperties(appId = Some((_: Session) => "my-app".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getAppId shouldBe "my-app"
+  }
+
+  it should "set clusterId correctly" in {
+    val props  = AmqpMessageProperties(clusterId = Some((_: Session) => "cluster-1".success))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Success[_]]
+    result.toOption.get.getClusterId shouldBe "cluster-1"
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/request/AmqpProtocolMessageSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/AmqpProtocolMessageSpec.scala
@@ -1,0 +1,90 @@
+package org.galaxio.gatling.amqp.request
+
+import com.rabbitmq.client.AMQP
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AmqpProtocolMessageSpec extends AnyFlatSpec with Matchers {
+
+  private def basicProps(
+      messageId: String = null,
+      correlationId: String = null,
+  ): AMQP.BasicProperties =
+    new AMQP.BasicProperties.Builder()
+      .messageId(messageId)
+      .correlationId(correlationId)
+      .build()
+
+  "AmqpProtocolMessage" should "return correlationId from properties" in {
+    val msg = AmqpProtocolMessage(basicProps(correlationId = "corr-1"), Array.emptyByteArray)
+
+    msg.correlationId shouldBe "corr-1"
+  }
+
+  it should "produce a copy with new correlationId" in {
+    val original = AmqpProtocolMessage(basicProps(correlationId = "old-corr"), "hello".getBytes)
+    val modified = original.correlationId("new-corr")
+
+    modified.correlationId shouldBe "new-corr"
+    original.correlationId shouldBe "old-corr"
+  }
+
+  it should "return messageId from properties" in {
+    val msg = AmqpProtocolMessage(basicProps(messageId = "msg-1"), Array.emptyByteArray)
+
+    msg.messageId shouldBe "msg-1"
+  }
+
+  it should "produce a copy with new messageId" in {
+    val original = AmqpProtocolMessage(basicProps(messageId = "old-msg"), "data".getBytes)
+    val modified = original.messageId("new-msg")
+
+    modified.messageId shouldBe "new-msg"
+    original.messageId shouldBe "old-msg"
+  }
+
+  it should "preserve payload after correlationId copy" in {
+    val payload  = "test payload".getBytes
+    val original = AmqpProtocolMessage(basicProps(), payload)
+    val modified = original.correlationId("new-corr")
+
+    modified.payload shouldBe payload
+  }
+
+  it should "preserve payload after messageId copy" in {
+    val payload  = "test payload".getBytes
+    val original = AmqpProtocolMessage(basicProps(), payload)
+    val modified = original.messageId("new-msg")
+
+    modified.payload shouldBe payload
+  }
+
+  it should "preserve responseCode after copy" in {
+    val original = AmqpProtocolMessage(basicProps(), Array.emptyByteArray, responseCode = Some("200"))
+    val modified = original.correlationId("new-corr")
+
+    modified.responseCode shouldBe Some("200")
+  }
+
+  it should "default responseCode to None" in {
+    val msg = AmqpProtocolMessage(basicProps(), Array.emptyByteArray)
+
+    msg.responseCode shouldBe None
+  }
+
+  it should "not mutate the original message when setting correlationId" in {
+    val original = AmqpProtocolMessage(basicProps(correlationId = "c1", messageId = "m1"), Array.emptyByteArray)
+    val _        = original.correlationId("c2")
+
+    original.correlationId shouldBe "c1"
+    original.messageId shouldBe "m1"
+  }
+
+  it should "not mutate the original message when setting messageId" in {
+    val original = AmqpProtocolMessage(basicProps(correlationId = "c1", messageId = "m1"), Array.emptyByteArray)
+    val _        = original.messageId("m2")
+
+    original.correlationId shouldBe "c1"
+    original.messageId shouldBe "m1"
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/request/ConsumeDslBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/ConsumeDslBuilderSpec.scala
@@ -1,0 +1,78 @@
+package org.galaxio.gatling.amqp.request
+
+import io.gatling.commons.validation._
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.session.Session
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConsumeDslBuilderSpec extends AnyFlatSpec with Matchers {
+
+  private val configuration = GatlingConfiguration.loadForTest()
+
+  private val requestName = (_: Session) => "test-consume".success
+  private val queueName   = (_: Session) => "test-queue".success
+
+  private def defaultBuilder: ConsumeDslBuilder =
+    ConsumeDslBuilder(ConsumeAttributes(requestName, queueName), configuration)
+
+  "ConsumeDslBuilder" should "have default timeout of 5000" in {
+    val builder = defaultBuilder
+
+    builder.attributes.timeout shouldBe 5000L
+  }
+
+  it should "set timeout value" in {
+    val builder = defaultBuilder.timeout(10000L)
+
+    builder.attributes.timeout shouldBe 10000L
+  }
+
+  it should "have empty checks list by default" in {
+    val builder = defaultBuilder
+
+    builder.attributes.checks shouldBe empty
+  }
+
+  it should "have silent as false by default" in {
+    val builder = defaultBuilder
+
+    builder.attributes.silent shouldBe false
+  }
+
+  it should "set silent flag to true" in {
+    val builder = defaultBuilder.silent
+
+    builder.attributes.silent shouldBe true
+  }
+
+  it should "build an ActionBuilder" in {
+    val actionBuilder = defaultBuilder.build()
+
+    actionBuilder should not be null
+  }
+
+  it should "be immutable - timeout returns new instance" in {
+    val original = defaultBuilder
+    val modified = original.timeout(20000L)
+
+    original.attributes.timeout shouldBe 5000L
+    modified.attributes.timeout shouldBe 20000L
+  }
+
+  it should "be immutable - silent returns new instance" in {
+    val original = defaultBuilder
+    val modified = original.silent
+
+    original.attributes.silent shouldBe false
+    modified.attributes.silent shouldBe true
+  }
+
+  "ConsumeDslBuilderQueue" should "create ConsumeDslBuilder with queue name" in {
+    val queueBuilder = ConsumeDslBuilderQueue(requestName, configuration)
+    val builder      = queueBuilder.queue(queueName)
+
+    builder.attributes.queueName should not be null
+    builder.attributes.requestName should not be null
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderSpec.scala
@@ -1,0 +1,185 @@
+package org.galaxio.gatling.amqp.request
+
+import io.gatling.commons.stats.OK
+import io.gatling.commons.validation._
+import io.gatling.core.action.Action
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.structure.ScenarioContext
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PublishDslBuilderSpec extends AnyFlatSpec with Matchers {
+
+  private val session = Session(
+    scenario = "test",
+    userId = 0L,
+    attributes = Map.empty,
+    baseStatus = OK,
+    blockStack = Nil,
+    onExit = Session.NothingOnExit,
+    eventLoop = null,
+  )
+
+  private val noopActionBuilder: ActionBuilder = new ActionBuilder {
+    override def build(ctx: ScenarioContext, next: Action): Action = next
+  }
+
+  private val requestName: Expression[String] = (_: Session) => "test-request".success
+
+  private val dummyExchange: AmqpExchange = AmqpQueueExchange((_: Session) => "test-queue".success)
+
+  private val dummyMessage: AmqpMessage =
+    TextAmqpMessage((_: Session) => "hello".success, java.nio.charset.StandardCharsets.UTF_8)
+
+  private var capturedAttributes: Option[AmqpAttributes] = None
+
+  private val capturingFactory: AmqpAttributes => ActionBuilder = attrs => {
+    capturedAttributes = Some(attrs)
+    noopActionBuilder
+  }
+
+  private def defaultAttrs: AmqpAttributes = AmqpAttributes(
+    requestName = requestName,
+    destination = dummyExchange,
+    selector = None,
+    message = dummyMessage,
+  )
+
+  private def defaultBuilder: PublishDslBuilder = PublishDslBuilder(defaultAttrs, capturingFactory)
+
+  override def withFixture(test: NoArgTest) = {
+    capturedAttributes = None
+    super.withFixture(test)
+  }
+
+  "PublishDslBuilder" should "set messageId in message properties" in {
+    val expr    = (_: Session) => "msg-id-1".success
+    val builder = defaultBuilder.messageId(expr)
+
+    builder.attributes.messageProperties.messageId shouldBe defined
+    builder.attributes.messageProperties.messageId.get(session) shouldBe "msg-id-1".success
+  }
+
+  it should "set priority in message properties" in {
+    val expr    = (_: Session) => 5.success
+    val builder = defaultBuilder.priority(expr)
+
+    builder.attributes.messageProperties.priority shouldBe defined
+    builder.attributes.messageProperties.priority.get(session) shouldBe 5.success
+  }
+
+  it should "set contentType in message properties" in {
+    val expr    = (_: Session) => "application/json".success
+    val builder = defaultBuilder.contentType(expr)
+
+    builder.attributes.messageProperties.contentType shouldBe defined
+    builder.attributes.messageProperties.contentType.get(session) shouldBe "application/json".success
+  }
+
+  it should "set contentEncoding in message properties" in {
+    val expr    = (_: Session) => "utf-8".success
+    val builder = defaultBuilder.contentEncoding(expr)
+
+    builder.attributes.messageProperties.contentEncoding shouldBe defined
+    builder.attributes.messageProperties.contentEncoding.get(session) shouldBe "utf-8".success
+  }
+
+  it should "set correlationId in message properties" in {
+    val expr    = (_: Session) => "corr-1".success
+    val builder = defaultBuilder.correlationId(expr)
+
+    builder.attributes.messageProperties.correlationId shouldBe defined
+    builder.attributes.messageProperties.correlationId.get(session) shouldBe "corr-1".success
+  }
+
+  it should "set replyTo in message properties" in {
+    val expr    = (_: Session) => "reply-q".success
+    val builder = defaultBuilder.replyTo(expr)
+
+    builder.attributes.messageProperties.replyTo shouldBe defined
+    builder.attributes.messageProperties.replyTo.get(session) shouldBe "reply-q".success
+  }
+
+  it should "set expiration in message properties" in {
+    val expr    = (_: Session) => "60000".success
+    val builder = defaultBuilder.expiration(expr)
+
+    builder.attributes.messageProperties.expiration shouldBe defined
+    builder.attributes.messageProperties.expiration.get(session) shouldBe "60000".success
+  }
+
+  it should "add a single header" in {
+    val builder = defaultBuilder.header("x-custom", (_: Session) => "value1".success)
+
+    builder.attributes.messageProperties.headers should have size 1
+    builder.attributes.messageProperties.headers("x-custom")(session) shouldBe "value1".success
+  }
+
+  it should "add multiple headers via headers method" in {
+    val builder = defaultBuilder.headers(
+      "h1" -> ((_: Session) => "v1".success),
+      "h2" -> ((_: Session) => "v2".success),
+    )
+
+    builder.attributes.messageProperties.headers should have size 2
+  }
+
+  it should "accumulate headers from multiple header calls" in {
+    val builder = defaultBuilder
+      .header("h1", (_: Session) => "v1".success)
+      .header("h2", (_: Session) => "v2".success)
+
+    builder.attributes.messageProperties.headers should have size 2
+  }
+
+  it should "call factory with final attributes when build is invoked" in {
+    val expr    = (_: Session) => "msg-42".success
+    val builder = defaultBuilder.messageId(expr)
+
+    builder.build()
+
+    capturedAttributes shouldBe defined
+    capturedAttributes.get.messageProperties.messageId shouldBe defined
+  }
+
+  it should "set amqpType in message properties" in {
+    val expr    = (_: Session) => "my-type".success
+    val builder = defaultBuilder.amqpType(expr)
+
+    builder.attributes.messageProperties.`type` shouldBe defined
+    builder.attributes.messageProperties.`type`.get(session) shouldBe "my-type".success
+  }
+
+  it should "set userId in message properties" in {
+    val expr    = (_: Session) => "user1".success
+    val builder = defaultBuilder.userId(expr)
+
+    builder.attributes.messageProperties.userId shouldBe defined
+    builder.attributes.messageProperties.userId.get(session) shouldBe "user1".success
+  }
+
+  it should "set appId in message properties" in {
+    val expr    = (_: Session) => "app1".success
+    val builder = defaultBuilder.appId(expr)
+
+    builder.attributes.messageProperties.appId shouldBe defined
+    builder.attributes.messageProperties.appId.get(session) shouldBe "app1".success
+  }
+
+  it should "set clusterId in message properties" in {
+    val expr    = (_: Session) => "cluster1".success
+    val builder = defaultBuilder.clusterId(expr)
+
+    builder.attributes.messageProperties.clusterId shouldBe defined
+    builder.attributes.messageProperties.clusterId.get(session) shouldBe "cluster1".success
+  }
+
+  it should "not modify original builder when setting properties" in {
+    val original = defaultBuilder
+    val modified = original.messageId((_: Session) => "msg-1".success)
+
+    original.attributes.messageProperties.messageId shouldBe None
+    modified.attributes.messageProperties.messageId shouldBe defined
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix 4 critical bugs**: priority setting deliveryMode instead of priority, pool config never applied to GenericObjectPool, channel leak on exception in WithAmqpChannel, Java matchByCorrelationId() delegating to matchByMessageId()
- **Add production infrastructure**: configurable channel pool size, advanced RabbitMQ connection settings (auto-recovery, SSL/TLS, timeouts, heartbeat), graceful shutdown with consumer cancellation, publisher confirms
- **Add new Gatling features**: silent mode (suppress stats logging), consume action (pull messages via basicGet)
- **Add 92 unit tests** across 7 spec files — all runnable without RabbitMQ
- **Improve CI**: separate format job, Java 17+21 matrix, external changelog config with 12 categories, workflow_dispatch trigger
- **Rewrite README** with full feature documentation, installation for sbt/Maven/Gradle, all actions, checks, silent mode, publisher confirms

## Bug Fixes

| Bug | File | Fix |
|-----|------|-----|
| priority sets deliveryMode instead of priority | AmqpMessageProperties.scala:45 | bp.deliveryMode(i) to bp.priority(i) |
| Pool config created but never passed to GenericObjectPool | AmqpConnectionPool.scala:16 | Pass poolConfig to constructor |
| Channel leak on exception | WithAmqpChannel.scala | try/catch with invalidate on shutdown exceptions |
| Java matchByCorrelationId() delegates wrong | AmqpProtocolBuilder.java:35 | matchByMessageId() to matchByCorrelationId() |
| Errant field declaration usePersistentDeliveryMode | AmqpProtocolBuilder.java:12 | Removed stray field |

## New Features

- **Silent mode**: .silent on publish, request-reply, and consume actions
- **Consume action**: amqp(name).consume.queue(q).timeout(5000).check(...)
- **Publisher confirms**: .usePublisherConfirms on protocol builder
- **Configurable pool**: .channelPoolSize(32) on protocol builder
- **Advanced connection**: .automaticRecovery(), .useSslProtocol(), .connectionTimeout(), .requestedHeartbeat(), etc.
- **Graceful shutdown**: TrackerPool cancels consumers and closes channels on exit

## Breaking Changes

AmqpProtocol and AmqpConnectionPool constructors have new parameters (channelPoolSize, publisherConfirms). All new parameters have defaults, so named-parameter usage is unaffected.

## Test plan

- [x] sbt clean compile — compiles with no errors
- [x] sbt scalafmtCheckAll — formatting passes
- [x] sbt test — 92 unit tests pass (no RabbitMQ needed)
- [ ] Integration tests with RabbitMQ
- [ ] Verify Java/Kotlin examples compile and work

Generated with [Claude Code](https://claude.com/claude-code)