### PR TITLE
deps: update amqp-client to 5.30.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     "io.gatling"            % "gatling-test-framework"    % gatlingVersion % "it,test",
   )
 
-  lazy val rabbitmq    = "com.rabbitmq"       % "amqp-client"   % "5.28.0"
+  lazy val rabbitmq    = "com.rabbitmq"       % "amqp-client"   % "5.30.0"
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.13.1"
   lazy val fastUUID    = "com.eatthepath"     % "fast-uuid"     % "0.2.0"
 


### PR DESCRIPTION
## Summary
- Update `com.rabbitmq:amqp-client` from 5.28.0 to 5.30.0
- Rebased from stale Scala Steward branch `update/amqp-client-5.30.0` onto current `main`

## Test plan
- [ ] CI compiles and tests pass
- [ ] Verify RabbitMQ integration test works with new client version

🤖 Generated with [Claude Code](https://claude.com/claude-code)