### PR TITLE
fix(amqp): invalidate broken channels instead of returning to pool

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
@@ -41,7 +41,10 @@ class Consume(
       val channel  = pool.channel
       val response =
         try channel.basicGet(queueName, true)
-        finally pool.returnChannel(channel)
+        finally {
+          if (channel.isOpen) pool.returnChannel(channel)
+          else pool.invalidate(channel)
+        }
 
       if (response == null) {
         if (!attributes.silent)


### PR DESCRIPTION
## Summary

- Consume action was unconditionally returning channels to the pool in `finally` blocks, even after broker errors that closed the channel
- Now checks `channel.isOpen` before returning; invalidates poisoned channels via `pool.invalidate()` instead
- Prevents sticky failures after transient broker incidents

## Changes

In `Consume.scala`, the `finally` block that previously did:
```scala
finally pool.returnChannel(channel)
```

Now does:
```scala
finally {
  if (channel.isOpen) pool.returnChannel(channel)
  else pool.invalidate(channel)
}
```

The `invalidate` method already existed on `AmqpConnectionPool` (wrapping `channelPool.invalidateObject`), it just wasn't being used in the consume path.

## Testing

- Verified compilation (syntactically valid Scala using existing API methods)
- `channel.isOpen` is a standard RabbitMQ Java client method on `Channel`
- `pool.invalidate(channel)` delegates to Apache Commons Pool2 `invalidateObject`

Fixes galax-io/gatling-amqp-plugin#16