### PR TITLE
fix(amqp): tie TrackerPool lifecycle to protocol shutdown, not per-user exit

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpComponents.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpComponents.scala
@@ -13,5 +13,5 @@ case class AmqpComponents(
 ) extends ProtocolComponents {
   override def onStart: Session => Session = Session.Identity
 
-  override def onExit: Session => Unit = _ => trackerPool.close()
+  override def onExit: Session => Unit = _ => ()
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
@@ -85,6 +85,7 @@ object AmqpProtocol {
 
         amqpProtocol.initActions.foreach(runInitAction(requestPool.channel))
         val trackerPool = getOrCreateTrackerPool(coreComponents, replyPool)
+        coreComponents.actorSystem.registerOnTermination(trackerPool.close())
 
         AmqpComponents(amqpProtocol, requestPool, replyPool, trackerPool)
       }


### PR DESCRIPTION
## Summary\n\n`TrackerPool` is shared at protocol level but was being closed from per-user `onExit`, allowing one finished virtual user to tear down reply consumers still needed by other active users. This caused cross-user interference, false KO reply timeouts, and unstable results under staggered workloads.\n\n## Changes\n\n- **AmqpProtocol.scala**: Register `trackerPool.close()` on `ActorSystem` termination via `registerOnTermination`, matching the existing pattern already used for `requestPool` and `replyPool`.\n- **AmqpComponents.scala**: Make `onExit` a no-op (`_ => ()`) since the shared pool lifecycle is now managed at protocol/simulation level.\n\n## Testing\n\n- Verified the fix follows the identical cleanup pattern used for connection pools (lines 82-84 in AmqpProtocol.scala).\n- The change is minimal and mechanical — no new logic paths introduced.\n\nFixes galax-io/gatling-amqp-plugin#15