### PR TITLE
fix(amqp): clean up dynamic reply queue trackers to prevent resource leaks

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
@@ -40,14 +40,16 @@ class RequestReply(
       publisher: AmqpPublisher,
   ): Unit =
     resolveDestination(replyDestination, session).map { qName =>
-      val tracker = components.trackerPool.tracker(
+      val trackerPool = components.trackerPool
+      val tracker     = trackerPool.tracker(
         qName,
         components.protocol.consumersThreadCount,
         components.protocol.messageMatcher,
         components.protocol.responseTransformer,
       )
-      val id      = components.protocol.messageMatcher.requestMatchId(msg)
-      val now     = clock.nowMillis
+      trackerPool.incrementPending(qName)
+      val id          = components.protocol.messageMatcher.requestMatchId(msg)
+      val now         = clock.nowMillis
       try {
         publisher.publish(msg, session)
         if (logger.underlying.isDebugEnabled) {
@@ -62,9 +64,11 @@ class RequestReply(
           next,
           requestNameString,
           attributes.silent,
+          onComplete = Some(() => trackerPool.decrementPendingAndEvict(qName)),
         )
       } catch {
         case e: Throwable =>
+          trackerPool.decrementPendingAndEvict(qName)
           logger.error(e.getMessage, e)
           if (!attributes.silent)
             statsEngine.logResponse(

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTracker.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTracker.scala
@@ -17,6 +17,7 @@ class AmqpMessageTracker(actor: ActorRef[AmqpMessageTrackerActor.AmqpMessage]) {
       next: Action,
       requestName: String,
       silent: Boolean = false,
+      onComplete: Option[() => Unit] = None,
   ): Unit =
     actor ! MessagePublished(
       matchId,
@@ -27,5 +28,6 @@ class AmqpMessageTracker(actor: ActorRef[AmqpMessageTrackerActor.AmqpMessage]) {
       next,
       requestName,
       silent,
+      onComplete,
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
@@ -83,7 +83,9 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
         }
       }
 
-      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent, onComplete) <- timedOutMessages) {
+      for (
+        MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent, onComplete) <- timedOutMessages
+      ) {
         sentMessages.remove(matchId)
         executeNext(
           session.markAsFailed,

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
@@ -28,6 +28,7 @@ object AmqpMessageTrackerActor {
       next: Action,
       requestName: String,
       silent: Boolean = false,
+      onComplete: Option[() => Unit] = None,
   ) extends AmqpMessage
 
   final case class MessageConsumed(
@@ -66,8 +67,10 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
     // message was received; publish stats and remove from the map
     case MessageConsumed(matchId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
-      sentMessages.remove(matchId).foreach { case MessagePublished(_, sent, _, checks, session, next, requestName, silent) =>
-        processMessage(session, sent, received, checks, message, next, requestName, silent)
+      sentMessages.remove(matchId).foreach {
+        case MessagePublished(_, sent, _, checks, session, next, requestName, silent, onComplete) =>
+          processMessage(session, sent, received, checks, message, next, requestName, silent)
+          onComplete.foreach(_())
       }
       stay
 
@@ -80,7 +83,7 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
         }
       }
 
-      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent) <- timedOutMessages) {
+      for (MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent, onComplete) <- timedOutMessages) {
         sentMessages.remove(matchId)
         executeNext(
           session.markAsFailed,
@@ -93,6 +96,7 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
           Some(s"Reply timeout after $receivedTimeout ms"),
           silent,
         )
+        onComplete.foreach(_())
       }
       timedOutMessages.clear()
       stay

--- a/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
@@ -11,6 +11,7 @@ import org.galaxio.gatling.amqp.protocol.AmqpMessageMatcher
 import org.galaxio.gatling.amqp.request.AmqpProtocolMessage
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.util.Try
 
@@ -22,7 +23,8 @@ class TrackerPool(
 ) extends AmqpLogging with NameGen {
 
   private val trackers        = new ConcurrentHashMap[String, AmqpMessageTracker]
-  private val consumerEntries = mutable.ArrayBuffer.empty[(Channel, String)]
+  private val consumerEntries = new ConcurrentHashMap[String, mutable.ArrayBuffer[(Channel, String)]]
+  private val pendingCounts   = new ConcurrentHashMap[String, AtomicInteger]
 
   def tracker(
       sourceQueue: String,
@@ -35,6 +37,8 @@ class TrackerPool(
       _ => {
         val actor =
           system.actorOf(new AmqpMessageTrackerActor(genName("amqpTrackerActor"), statsEngine, clock))
+
+        val entries = mutable.ArrayBuffer.empty[(Channel, String)]
 
         for (_ <- 1 to listenerThreadCount) {
           val consumerChannel = pool.createConsumerChannel
@@ -57,21 +61,54 @@ class TrackerPool(
             },
             (_: String) => (),
           )
-          consumerEntries.synchronized {
-            consumerEntries += ((consumerChannel, consumerTag))
-          }
+          entries += ((consumerChannel, consumerTag))
         }
 
+        consumerEntries.put(sourceQueue, entries)
         new AmqpMessageTracker(actor)
       },
     )
 
-  def close(): Unit =
-    consumerEntries.synchronized {
-      consumerEntries.foreach { case (channel, tag) =>
+  /** Increment the pending message count for the given queue.
+    * Must be called before tracking a message for proper cleanup.
+    */
+  def incrementPending(sourceQueue: String): Unit =
+    pendingCounts.computeIfAbsent(sourceQueue, _ => new AtomicInteger(0)).incrementAndGet()
+
+  /** Decrement the pending message count and remove the tracker if it reaches zero.
+    * This ensures dynamic (per-request or per-user) reply queues are cleaned up
+    * once all expected replies have been consumed.
+    */
+  def decrementPendingAndEvict(sourceQueue: String): Unit = {
+    val count = pendingCounts.get(sourceQueue)
+    if (count != null && count.decrementAndGet() <= 0) {
+      removeTracker(sourceQueue)
+    }
+  }
+
+  /** Remove a tracker and release its consumers and channels.
+    * Use for dynamic (per-request or per-user) reply queues that are no longer needed.
+    */
+  def removeTracker(sourceQueue: String): Unit = {
+    trackers.remove(sourceQueue)
+    pendingCounts.remove(sourceQueue)
+    Option(consumerEntries.remove(sourceQueue)).foreach { entries =>
+      entries.foreach { case (channel, tag) =>
         Try(channel.basicCancel(tag))
         Try(channel.close())
       }
-      consumerEntries.clear()
     }
+  }
+
+  def close(): Unit = {
+    import scala.jdk.CollectionConverters._
+    consumerEntries.values().asScala.foreach { entries =>
+      entries.foreach { case (channel, tag) =>
+        Try(channel.basicCancel(tag))
+        Try(channel.close())
+      }
+    }
+    consumerEntries.clear()
+    trackers.clear()
+  }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
@@ -69,26 +69,16 @@ class TrackerPool(
       },
     )
 
-  /** Increment the pending message count for the given queue.
-    * Must be called before tracking a message for proper cleanup.
-    */
   def incrementPending(sourceQueue: String): Unit =
     pendingCounts.computeIfAbsent(sourceQueue, _ => new AtomicInteger(0)).incrementAndGet()
 
-  /** Decrement the pending message count and remove the tracker if it reaches zero.
-    * This ensures dynamic (per-request or per-user) reply queues are cleaned up
-    * once all expected replies have been consumed.
-    */
   def decrementPendingAndEvict(sourceQueue: String): Unit = {
     val count = pendingCounts.get(sourceQueue)
-    if (count != null && count.decrementAndGet() <= 0) {
+    if (count != null && count.decrementAndGet() == 0) {
       removeTracker(sourceQueue)
     }
   }
 
-  /** Remove a tracker and release its consumers and channels.
-    * Use for dynamic (per-request or per-user) reply queues that are no longer needed.
-    */
   def removeTracker(sourceQueue: String): Unit = {
     trackers.remove(sourceQueue)
     pendingCounts.remove(sourceQueue)


### PR DESCRIPTION
## Summary

- `TrackerPool` accumulated tracker entries indefinitely when reply queues were dynamic (per-user or per-request), leaking consumers, channels, and memory
- Added reference-counted eviction: pending messages are counted per queue, and when all replies are consumed (or timed out), the tracker is removed along with its consumers and channels
- For static shared queues (same name across all sessions), the tracker naturally stays alive as long as messages are in flight

## Changes

- **`TrackerPool.scala`**: Changed `consumerEntries` to per-queue tracking (keyed `ConcurrentHashMap`). Added `pendingCounts` atomic counter map. Added `incrementPending`, `decrementPendingAndEvict`, and `removeTracker` methods.
- **`AmqpMessageTrackerActor.scala`**: Added optional `onComplete` callback to `MessagePublished`. Callback is invoked after reply consumption or timeout.
- **`AmqpMessageTracker.scala`**: Extended `track()` with optional `onComplete` parameter.
- **`RequestReply.scala`**: Increments pending count before publishing, passes cleanup callback to `track()`, decrements on exception path.

## Testing

- Verified compilation against Scala 2.13 / Gatling 3.13 dependencies
- The fix is backward-compatible: static queues with continuous traffic will never have their pending count drop to zero, so they remain cached as before

Fixes galax-io/gatling-amqp-plugin#17