### PR TITLE
fix: normalize failure propagation in publish and request-reply actions

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
@@ -51,6 +51,8 @@ class Publish(
             Some("500"),
             Some(e.getMessage),
           )
+        next ! session.markAsFailed
+        return
     }
     next ! session
   }

--- a/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
@@ -37,6 +37,7 @@ class Publish(
       }
       if (!attributes.silent)
         statsEngine.logResponse(session.scenario, session.groups, requestNameString, now, clock.nowMillis, OK, None, None)
+      next ! session
     } catch {
       case e: Throwable =>
         logger.error(e.getMessage, e)
@@ -52,8 +53,6 @@ class Publish(
             Some(e.getMessage),
           )
         next ! session.markAsFailed
-        return
     }
-    next ! session
   }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
@@ -2,7 +2,7 @@ package org.galaxio.gatling.amqp.action
 
 import io.gatling.commons.stats.KO
 import io.gatling.commons.util.Clock
-import io.gatling.commons.validation.Validation
+import io.gatling.commons.validation.{Failure, Success, Validation}
 import io.gatling.core.action.Action
 import io.gatling.core.actor.ActorRef
 import io.gatling.core.controller.throttle.Throttler
@@ -39,48 +39,65 @@ class RequestReply(
       session: Session,
       publisher: AmqpPublisher,
   ): Unit =
-    resolveDestination(replyDestination, session).map { qName =>
-      val trackerPool = components.trackerPool
-      val tracker     = trackerPool.tracker(
-        qName,
-        components.protocol.consumersThreadCount,
-        components.protocol.messageMatcher,
-        components.protocol.responseTransformer,
-      )
-      trackerPool.incrementPending(qName)
-      val id          = components.protocol.messageMatcher.requestMatchId(msg)
-      val now         = clock.nowMillis
-      try {
-        publisher.publish(msg, session)
-        if (logger.underlying.isDebugEnabled) {
-          logMessage(s"Message sent user=${session.userId} AMQPMessageID=${msg.messageId}", msg)
-        }
-        tracker.track(
-          id,
-          clock.nowMillis,
-          replyTimeout,
-          attributes.checks,
-          session,
-          next,
-          requestNameString,
-          attributes.silent,
-          onComplete = Some(() => trackerPool.decrementPendingAndEvict(qName)),
+    resolveDestination(replyDestination, session) match {
+      case Success(qName)        =>
+        val trackerPool = components.trackerPool
+        val tracker     = trackerPool.tracker(
+          qName,
+          components.protocol.consumersThreadCount,
+          components.protocol.messageMatcher,
+          components.protocol.responseTransformer,
         )
-      } catch {
-        case e: Throwable =>
-          trackerPool.decrementPendingAndEvict(qName)
-          logger.error(e.getMessage, e)
-          if (!attributes.silent)
-            statsEngine.logResponse(
-              session.scenario,
-              session.groups,
-              requestNameString,
-              now,
-              clock.nowMillis,
-              KO,
-              Some("500"),
-              Some(e.getMessage),
-            )
-      }
+        trackerPool.incrementPending(qName)
+        val id          = components.protocol.messageMatcher.requestMatchId(msg)
+        val now         = clock.nowMillis
+        try {
+          publisher.publish(msg, session)
+          if (logger.underlying.isDebugEnabled) {
+            logMessage(s"Message sent user=${session.userId} AMQPMessageID=${msg.messageId}", msg)
+          }
+          tracker.track(
+            id,
+            clock.nowMillis,
+            replyTimeout,
+            attributes.checks,
+            session,
+            next,
+            requestNameString,
+            attributes.silent,
+            onComplete = Some(() => trackerPool.decrementPendingAndEvict(qName)),
+          )
+        } catch {
+          case e: Throwable =>
+            trackerPool.decrementPendingAndEvict(qName)
+            logger.error(e.getMessage, e)
+            if (!attributes.silent)
+              statsEngine.logResponse(
+                session.scenario,
+                session.groups,
+                requestNameString,
+                now,
+                clock.nowMillis,
+                KO,
+                Some("500"),
+                Some(e.getMessage),
+              )
+            next ! session.markAsFailed
+        }
+      case Failure(errorMessage) =>
+        val now = clock.nowMillis
+        logger.error(s"Failed to resolve reply destination: $errorMessage")
+        if (!attributes.silent)
+          statsEngine.logResponse(
+            session.scenario,
+            session.groups,
+            requestNameString,
+            now,
+            clock.nowMillis,
+            KO,
+            Some("500"),
+            Some(errorMessage),
+          )
+        next ! session.markAsFailed
     }
 }


### PR DESCRIPTION
## Summary

Fixes #21 — normalizes error handling in AMQP publish and request-reply actions so that every failure path marks the session as failed, logs the request as KO, and always continues the action chain deterministically.

## Changes

- **Publish**: on exception, now marks session as failed (`session.markAsFailed`) before passing to the next action. Previously the original (non-failed) session was forwarded, making broker errors silent false positives.
- **RequestReply**: on publish exception, now marks session as failed AND calls `next ! session.markAsFailed`. Previously the action chain was broken entirely on failure (next action never received control).
- **RequestReply**: handles destination resolution failure (`Validation.Failure`) by logging KO and continuing with a failed session. Previously a failed resolution was silently dropped with no logging and no continuation.

## Test plan

- [x] All 98 existing tests pass (`sbt clean compile test`)
- [x] `scalafmtAll` applied
- [ ] Integration tests with broker unavailability (can be added as follow-up)

---

Fixes galax-io/gatling-amqp-plugin#21