### PR TITLE
fix: scope AMQP pools and trackers per protocol instance

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
@@ -7,7 +7,6 @@ import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol.{Protocol, ProtocolKey}
 
-import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters._
 
 object AmqpProtocol {
@@ -16,52 +15,6 @@ object AmqpProtocol {
 
     override def defaultProtocolValue(configuration: GatlingConfiguration): AmqpProtocol =
       throw new IllegalStateException("Can't provide a default value for AmqpProtocol")
-
-    private val trackerPoolRef           = new AtomicReference[TrackerPool]()
-    private val connectionPublishPoolRef = new AtomicReference[AmqpConnectionPool]()
-    private val connectionReplyPoolRef   = new AtomicReference[AmqpConnectionPool]()
-
-    private def getOrCreateConnectionPublishPool(protocol: AmqpProtocol) = {
-      if (connectionPublishPoolRef.get() == null) {
-        connectionPublishPoolRef.lazySet(
-          new AmqpConnectionPool(
-            protocol.connectionFactory,
-            protocol.consumersThreadCount,
-            protocol.channelPoolSize,
-            protocol.publisherConfirms,
-          ),
-        )
-      }
-      connectionPublishPoolRef.get()
-    }
-
-    private def getOrCreateConnectionReplyPool(protocol: AmqpProtocol) = {
-      if (connectionReplyPoolRef.get() == null) {
-        connectionReplyPoolRef.lazySet(
-          new AmqpConnectionPool(
-            protocol.replyConnectionFactory,
-            protocol.consumersThreadCount,
-            protocol.channelPoolSize,
-            publisherConfirms = false,
-          ),
-        )
-      }
-      connectionReplyPoolRef.get()
-    }
-
-    private def getOrCreateTrackerPool(components: CoreComponents, pool: AmqpConnectionPool) = {
-      if (trackerPoolRef.get() == null) {
-        trackerPoolRef.lazySet(
-          new TrackerPool(
-            pool,
-            components.actorSystem,
-            components.statsEngine,
-            components.clock,
-          ),
-        )
-      }
-      trackerPoolRef.get()
-    }
 
     private def toJavaMap(map: Map[String, Any]): java.util.Map[String, Object] =
       map.asJava.asInstanceOf[java.util.Map[String, Object]]
@@ -78,9 +31,20 @@ object AmqpProtocol {
 
     override def newComponents(coreComponents: CoreComponents): AmqpProtocol => AmqpComponents =
       amqpProtocol => {
-        val requestPool = getOrCreateConnectionPublishPool(amqpProtocol)
+        val requestPool = new AmqpConnectionPool(
+          amqpProtocol.connectionFactory,
+          amqpProtocol.consumersThreadCount,
+          amqpProtocol.channelPoolSize,
+          amqpProtocol.publisherConfirms,
+        )
         coreComponents.actorSystem.registerOnTermination(requestPool.close())
-        val replyPool   = getOrCreateConnectionReplyPool(amqpProtocol)
+
+        val replyPool = new AmqpConnectionPool(
+          amqpProtocol.replyConnectionFactory,
+          amqpProtocol.consumersThreadCount,
+          amqpProtocol.channelPoolSize,
+          publisherConfirms = false,
+        )
         coreComponents.actorSystem.registerOnTermination(replyPool.close())
 
         if (amqpProtocol.initActions.nonEmpty) {
@@ -93,7 +57,13 @@ object AmqpProtocol {
           }
           requestPool.returnChannel(ch)
         }
-        val trackerPool = getOrCreateTrackerPool(coreComponents, replyPool)
+
+        val trackerPool = new TrackerPool(
+          replyPool,
+          coreComponents.actorSystem,
+          coreComponents.statsEngine,
+          coreComponents.clock,
+        )
         coreComponents.actorSystem.registerOnTermination(trackerPool.close())
 
         AmqpComponents(amqpProtocol, requestPool, replyPool, trackerPool)


### PR DESCRIPTION
## Summary

- Removes process-wide singleton `AtomicReference` fields (`trackerPoolRef`, `connectionPublishPoolRef`, `connectionReplyPoolRef`) from the `ProtocolKey` object
- Creates fresh `AmqpConnectionPool` and `TrackerPool` instances for each protocol in `newComponents`, scoping them to the protocol instance lifetime
- Lifecycle remains tied to `actorSystem.registerOnTermination` so pools are properly closed on shutdown

## Problem

The plugin stored publish pools, reply pools, and tracker pools in process-wide singletons via `AtomicReference` fields inside `AmqpProtocol.amqpProtocolKey`. The first initialized protocol configuration would be reused by all subsequent simulations or alternate broker configurations in the same JVM, breaking multi-broker correctness and making repeated in-process runs unsafe.

## Solution

Each call to `newComponents` now creates its own independent pools directly, without any shared mutable state. This is the minimal change needed — the `AmqpComponents` case class and all public APIs remain unchanged.

Fixes #20

## Test plan

- [x] All 92 existing unit tests pass
- [x] Compilation clean with no warnings
- [ ] Integration tests with Docker (require RabbitMQ container)
- [ ] Manual verification with `RequestReplyTwoBrokerExample` using two distinct brokers