### PR TITLE
fix: validate pooled channels on borrow and recovery paths

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpConnectionPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpConnectionPool.scala
@@ -17,6 +17,10 @@ class AmqpConnectionPool(
 
   private val poolConfig = new GenericObjectPoolConfig[Channel]()
   poolConfig.setMaxTotal(channelPoolSize)
+  poolConfig.setTestOnBorrow(true)
+  poolConfig.setTestOnReturn(true)
+  poolConfig.setTimeBetweenEvictionRuns(java.time.Duration.ofSeconds(30))
+  poolConfig.setMinEvictableIdleDuration(java.time.Duration.ofMinutes(5))
 
   private val channelPool: ObjectPool[Channel] =
     new GenericObjectPool[Channel](new AmqpChannelFactory(connection, publisherConfirms), poolConfig)
@@ -35,7 +39,9 @@ class AmqpConnectionPool(
   def channel: Channel                 = {
     channelPool.borrowObject()
   }
-  def returnChannel(ch: Channel): Unit = channelPool.returnObject(ch)
+  def returnChannel(ch: Channel): Unit =
+    if (ch.isOpen) channelPool.returnObject(ch)
+    else channelPool.invalidateObject(ch)
 
   def invalidate(ch: Channel): Unit = channelPool.invalidateObject(ch)
 }

--- a/src/test/scala/org/galaxio/gatling/amqp/integration/ChannelPoolRecoverySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/integration/ChannelPoolRecoverySpec.scala
@@ -1,0 +1,90 @@
+package org.galaxio.gatling.amqp.integration
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, RabbitMQContainer}
+import com.rabbitmq.client.ConnectionFactory
+import org.galaxio.gatling.amqp.client.AmqpConnectionPool
+import org.galaxio.gatling.amqp.tags.DockerTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
+
+class ChannelPoolRecoverySpec extends AnyWordSpec with Matchers with ForAllTestContainer {
+
+  override val container: RabbitMQContainer = RabbitMQContainer(
+    DockerImageName.parse("rabbitmq:3.13-management-alpine"),
+  )
+
+  private lazy val connectionFactory = {
+    val cf = new ConnectionFactory()
+    cf.setHost(container.host)
+    cf.setPort(container.amqpPort)
+    cf.setUsername(container.adminUsername)
+    cf.setPassword(container.adminPassword)
+    cf
+  }
+
+  "Channel pool validation" should {
+    "not return a closed channel on borrow" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 2, 4)
+      try {
+        // Borrow a channel and close it manually to simulate broker-side closure
+        val ch = pool.channel
+        ch.isOpen shouldBe true
+        ch.close()
+        ch.isOpen shouldBe false
+
+        // Return the closed channel; pool should invalidate it
+        pool.returnChannel(ch)
+
+        // Next borrow should get a fresh, open channel
+        val ch2 = pool.channel
+        ch2.isOpen shouldBe true
+        pool.returnChannel(ch2)
+      } finally {
+        pool.close()
+      }
+    }
+
+    "recover after multiple channels are closed" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 2, 4)
+      try {
+        // Borrow several channels and close them to poison the pool
+        val channels = (1 to 3).map(_ => pool.channel)
+        channels.foreach(_.isOpen shouldBe true)
+
+        // Simulate broker-side closure
+        channels.foreach(_.close())
+        channels.foreach(ch => pool.returnChannel(ch))
+
+        // All subsequent borrows should return open channels
+        val freshChannels = (1 to 3).map { _ =>
+          val ch = pool.channel
+          ch.isOpen shouldBe true
+          ch
+        }
+        freshChannels.foreach(pool.returnChannel)
+      } finally {
+        pool.close()
+      }
+    }
+
+    "invalidate explicitly closed channel" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 2, 4)
+      try {
+        val ch = pool.channel
+        ch.isOpen shouldBe true
+        ch.close()
+
+        // Explicit invalidation should not throw
+        pool.invalidate(ch)
+
+        // Pool should create a new valid channel
+        val ch2 = pool.channel
+        ch2.isOpen shouldBe true
+        pool.returnChannel(ch2)
+      } finally {
+        pool.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Enables `testOnBorrow` and `testOnReturn` in the channel pool config so closed/stale channels are validated before use
- Configures periodic eviction (every 30s) to remove channels idle for 5+ minutes
- `returnChannel` now invalidates closed channels instead of returning them to the pool
- Adds integration tests verifying pool recovery after broker-side channel closures

## Changes

- `AmqpConnectionPool.scala`: Added pool validation and eviction settings; defensive check in `returnChannel`
- `ChannelPoolRecoverySpec.scala`: New integration test covering closed-channel recovery scenarios

## Testing

- Integration tests (Testcontainers + RabbitMQ) cover:
  - Closed channel is never returned on borrow
  - Pool recovers after multiple channels are poisoned
  - Explicit invalidation works correctly
- Existing tests unaffected

Fixes galax-io/gatling-amqp-plugin#27