### PR TITLE
fix: preserve validation failures when resolving AMQP message properties

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/request/AmqpMessageProperties.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/AmqpMessageProperties.scala
@@ -39,30 +39,28 @@ object AmqpMessageProperties {
   def toBasicProperties(p: AmqpMessageProperties, s: Session): Validation[AMQP.BasicProperties] = {
     val bp = new AMQP.BasicProperties().builder()
     import p._
-    contentType(s, bp, bp.contentType)
-    contentEncoding(s, bp, bp.contentEncoding)
-    deliveryMode(s, bp, i => bp.deliveryMode(i))
-    priority(s, bp, i => bp.priority(i))
-    correlationId(s, bp, bp.correlationId)
-    replyTo(s, bp, bp.replyTo)
-    expiration(s, bp, bp.expiration)
-    messageId(s, bp, bp.messageId)
-    timestamp(s, bp, bp.timestamp)
-    `type`(s, bp, bp.`type`)
-    userId(s, bp, bp.userId)
-    appId(s, bp, bp.appId)
-    clusterId(s, bp, bp.clusterId)
-      .flatMap(b =>
-        headers
-          .foldLeft(Map.empty[String, AnyRef].success) { case (resolvedHeaders, (key, value)) =>
-            for {
-              v  <- value(s)
-              rh <- resolvedHeaders
-            } yield rh + (key -> v)
-          }
-          .map(h => b.headers(h.asJava)),
-      )
-      .map(_.build())
+    for {
+      b  <- contentType(s, bp, bp.contentType)
+      b  <- contentEncoding(s, b, b.contentEncoding)
+      b  <- deliveryMode(s, b, i => b.deliveryMode(i))
+      b  <- priority(s, b, i => b.priority(i))
+      b  <- correlationId(s, b, b.correlationId)
+      b  <- replyTo(s, b, b.replyTo)
+      b  <- expiration(s, b, b.expiration)
+      b  <- messageId(s, b, b.messageId)
+      b  <- timestamp(s, b, b.timestamp)
+      b  <- `type`(s, b, b.`type`)
+      b  <- userId(s, b, b.userId)
+      b  <- appId(s, b, b.appId)
+      b  <- clusterId(s, b, b.clusterId)
+      rh <- headers
+              .foldLeft(Map.empty[String, AnyRef].success) { case (resolvedHeaders, (key, value)) =>
+                for {
+                  v  <- value(s)
+                  rh <- resolvedHeaders
+                } yield rh + (key -> v)
+              }
+    } yield b.headers(rh.asJava).build()
 
   }
 }

--- a/src/test/scala/org/galaxio/gatling/amqp/request/AmqpMessagePropertiesSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/AmqpMessagePropertiesSpec.scala
@@ -187,4 +187,132 @@ class AmqpMessagePropertiesSpec extends AnyFlatSpec with Matchers {
     result shouldBe a[Success[_]]
     result.toOption.get.getClusterId shouldBe "cluster-1"
   }
+
+  it should "propagate failure from contentType expression" in {
+    val props  = AmqpMessageProperties(contentType = Some((_: Session) => "contentType resolution failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("contentType resolution failed"))
+  }
+
+  it should "propagate failure from contentEncoding expression" in {
+    val props  = AmqpMessageProperties(contentEncoding = Some((_: Session) => "contentEncoding failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("contentEncoding failed"))
+  }
+
+  it should "propagate failure from deliveryMode expression" in {
+    val props  = AmqpMessageProperties(deliveryMode = Some((_: Session) => "deliveryMode failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("deliveryMode failed"))
+  }
+
+  it should "propagate failure from priority expression" in {
+    val props  = AmqpMessageProperties(priority = Some((_: Session) => "priority failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("priority failed"))
+  }
+
+  it should "propagate failure from correlationId expression" in {
+    val props  = AmqpMessageProperties(correlationId = Some((_: Session) => "correlationId failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("correlationId failed"))
+  }
+
+  it should "propagate failure from replyTo expression" in {
+    val props  = AmqpMessageProperties(replyTo = Some((_: Session) => "replyTo failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("replyTo failed"))
+  }
+
+  it should "propagate failure from expiration expression" in {
+    val props  = AmqpMessageProperties(expiration = Some((_: Session) => "expiration failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("expiration failed"))
+  }
+
+  it should "propagate failure from messageId expression" in {
+    val props  = AmqpMessageProperties(messageId = Some((_: Session) => "messageId failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("messageId failed"))
+  }
+
+  it should "propagate failure from timestamp expression" in {
+    val props  = AmqpMessageProperties(timestamp = Some((_: Session) => "timestamp failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("timestamp failed"))
+  }
+
+  it should "propagate failure from type expression" in {
+    val props  = AmqpMessageProperties(`type` = Some((_: Session) => "type failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("type failed"))
+  }
+
+  it should "propagate failure from userId expression" in {
+    val props  = AmqpMessageProperties(userId = Some((_: Session) => "userId failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("userId failed"))
+  }
+
+  it should "propagate failure from appId expression" in {
+    val props  = AmqpMessageProperties(appId = Some((_: Session) => "appId failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("appId failed"))
+  }
+
+  it should "propagate failure from clusterId expression" in {
+    val props  = AmqpMessageProperties(clusterId = Some((_: Session) => "clusterId failed".failure))
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("clusterId failed"))
+  }
+
+  it should "propagate failure from header expression" in {
+    val headers: Map[String, io.gatling.core.session.Expression[AnyRef]] = Map(
+      "x-good-header" -> ((_: Session) => ("value": AnyRef).success),
+      "x-bad-header"  -> ((_: Session) => "header resolution failed".failure),
+    )
+    val props                                                            = AmqpMessageProperties(headers = headers)
+    val result                                                           = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    result.onFailure(msg => msg should include("header resolution failed"))
+  }
+
+  it should "propagate the first failure when multiple properties fail" in {
+    val props  = AmqpMessageProperties(
+      contentType = Some((_: Session) => "contentType failed".failure),
+      messageId = Some((_: Session) => "messageId failed".failure),
+    )
+    val result = AmqpMessageProperties.toBasicProperties(props, session)
+
+    result shouldBe a[Failure]
+    // The first failure in the chain (contentType) should be reported
+    result.onFailure(msg => msg should include("contentType failed"))
+  }
 }


### PR DESCRIPTION
## Summary

Rewrites AMQP message property resolution as a single for-comprehension validation chain that preserves failures for every optional field. Previously, failures in properties like contentType, contentEncoding, deliveryMode, priority, correlationId, replyTo, expiration, messageId, timestamp, type, userId, and appId were silently discarded — only clusterId and headers failures propagated.

## Changes

- Refactored `AmqpMessageProperties.toBasicProperties` to use a for-comprehension that chains all property validations sequentially
- Any expression failure in any property now deterministically fails the request build path
- Added 15 unit tests covering failure propagation for every individual property and multi-failure scenarios

## Testing

- All 31 tests in `AmqpMessagePropertiesSpec` pass (16 existing + 15 new)
- All 66 tests in the `request` package pass

Fixes galax-io/gatling-amqp-plugin#24