### PR TITLE
fix(docs): correct Kotlin examples, implement consume timeout, fix request-reply docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,11 @@ val amqpConf = amqp
 
 ### Kotlin
 
+> **Note:** Kotlin examples use the Java API facade and are provided as reference. They are not compiled by CI (no Kotlin compiler plugin is configured in the build).
+
 - [Publish](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/PublishExample.kt)
 - [Request-Reply](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyExample.kt)
+- [Custom Matching](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyWithOwnMatchingExample.kt)
 - [Two Brokers](src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/RequestReplyTwoBrokerExample.kt)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ val amqpConf = amqp
 
 ### Consume
 
+Polls the queue for a message up to the specified timeout (default 5000ms). If no message arrives within the timeout, the action reports failure.
+
 ```scala
 amqp("consume").consume
   .queue("my-queue")

--- a/README.md
+++ b/README.md
@@ -247,11 +247,13 @@ amqp("publish-#{id}").publish
 ```scala
 amqp("request-reply").requestReply
   .topicExchange("request-exchange", "request.key")
-  .replyExchange("reply-exchange", "reply.key")
+  .replyExchange("reply-queue")
   .textMessage("""{"query": "data"}""")
   .messageId("#{msgId}")
   .check(jsonPath("$.result").is("ok"))
 ```
+
+The request destination supports `queueExchange`, `directExchange`, and `topicExchange`. The reply destination (`.replyExchange(name)`) specifies the queue where the plugin listens for replies. Reply routing is always queue-based.
 
 Multi-broker setup (publish to one broker, consume reply from another):
 

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilderMessage.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilderMessage.java
@@ -16,6 +16,7 @@ public class RequestReplyDslBuilderMessage {
         return this;
     }
 
+    @Deprecated
     public RequestReplyDslBuilderMessage noReplyTo(){
         this.wrapped = wrapped.noReplyTo();
         return this;

--- a/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Consume.scala
@@ -1,10 +1,11 @@
 package org.galaxio.gatling.amqp.action
 
-import io.gatling.commons.stats.{KO, OK}
+import com.rabbitmq.client.GetResponse
+import io.gatling.commons.stats.{KO, OK, Status}
 import io.gatling.commons.util.Clock
 import io.gatling.commons.validation.{Failure, Validation}
 import io.gatling.core.action.{Action, RequestAction}
-import io.gatling.core.actor.ActorRef
+import io.gatling.core.actor.{ActorRef, Scheduler}
 import io.gatling.core.check.Check
 import io.gatling.core.controller.throttle.Throttler
 import io.gatling.core.session.{Expression, Session}
@@ -13,9 +14,12 @@ import io.gatling.core.util.NameGen
 import org.galaxio.gatling.amqp.protocol.AmqpComponents
 import org.galaxio.gatling.amqp.request.{AmqpProtocolMessage, ConsumeAttributes}
 
+import scala.concurrent.duration._
+
 class Consume(
     attributes: ConsumeAttributes,
     components: AmqpComponents,
+    scheduler: Scheduler,
     val statsEngine: StatsEngine,
     val clock: Clock,
     val next: Action,
@@ -24,6 +28,8 @@ class Consume(
   override val name: String = genName("amqpConsume")
 
   override val requestName: Expression[String] = attributes.requestName
+
+  private val PollIntervalMillis = 100L
 
   override def sendRequest(session: Session): Validation[Unit] =
     for {
@@ -35,77 +41,75 @@ class Consume(
       )
 
   private def consumeAndLog(requestNameString: String, queueName: String, session: Session): Unit = {
-    val now = clock.nowMillis
-    try {
-      val pool     = components.connectionPublishPool
-      val channel  = pool.channel
-      val response =
-        try channel.basicGet(queueName, true)
+    val requestStart = clock.nowMillis
+    poll(requestNameString, queueName, session, requestStart, requestStart + attributes.timeout)
+  }
+
+  /** Non-blocking poll: each attempt borrows a channel, performs a single basicGet, and returns the channel immediately. If no
+    * message is available and the deadline has not passed, the next attempt is scheduled on the Gatling scheduler thread rather
+    * than blocking a user thread.
+    */
+  private def poll(
+      requestNameString: String,
+      queueName: String,
+      session: Session,
+      requestStart: Long,
+      deadline: Long,
+  ): Unit = {
+    val pool = components.connectionPublishPool
+
+    def logResult(s: Session, status: Status, responseCode: Option[String], message: Option[String]): Unit =
+      if (!attributes.silent)
+        statsEngine.logResponse(
+          s.scenario,
+          s.groups,
+          requestNameString,
+          requestStart,
+          clock.nowMillis,
+          status,
+          responseCode,
+          message,
+        )
+
+    val attempt: Either[Throwable, GetResponse] =
+      try {
+        val channel = pool.channel
+        try Right(channel.basicGet(queueName, true))
         finally {
           if (channel.isOpen) pool.returnChannel(channel)
           else pool.invalidate(channel)
         }
+      } catch {
+        case e: Throwable => Left(e)
+      }
 
-      if (response == null) {
-        if (!attributes.silent)
-          statsEngine.logResponse(
-            session.scenario,
-            session.groups,
-            requestNameString,
-            now,
-            clock.nowMillis,
-            KO,
-            None,
-            Some("No message available in queue"),
-          )
+    attempt match {
+      case Left(e) =>
+        logger.error(e.getMessage, e)
+        logResult(session, KO, Some("500"), Some(e.getMessage))
         next ! session.markAsFailed
-      } else {
+
+      case Right(response) if response != null =>
         val message             = AmqpProtocolMessage(response.getProps, response.getBody)
         val (newSession, error) = Check.check(message, session, attributes.checks)
         error match {
           case Some(Failure(errorMessage)) =>
-            if (!attributes.silent)
-              statsEngine.logResponse(
-                newSession.scenario,
-                newSession.groups,
-                requestNameString,
-                now,
-                clock.nowMillis,
-                KO,
-                message.responseCode,
-                Some(errorMessage),
-              )
+            logResult(newSession, KO, message.responseCode, Some(errorMessage))
             next ! newSession.markAsFailed
           case _                           =>
-            if (!attributes.silent)
-              statsEngine.logResponse(
-                newSession.scenario,
-                newSession.groups,
-                requestNameString,
-                now,
-                clock.nowMillis,
-                OK,
-                message.responseCode,
-                None,
-              )
+            logResult(newSession, OK, message.responseCode, None)
             next ! newSession
         }
-      }
-    } catch {
-      case e: Throwable =>
-        logger.error(e.getMessage, e)
-        if (!attributes.silent)
-          statsEngine.logResponse(
-            session.scenario,
-            session.groups,
-            requestNameString,
-            now,
-            clock.nowMillis,
-            KO,
-            Some("500"),
-            Some(e.getMessage),
-          )
-        next ! session.markAsFailed
+
+      case Right(_) =>
+        val remaining = deadline - clock.nowMillis
+        if (remaining <= 0) {
+          logResult(session, KO, None, Some(s"No message in queue within ${attributes.timeout}ms"))
+          next ! session.markAsFailed
+        } else {
+          val delay = math.min(PollIntervalMillis, remaining)
+          scheduler.scheduleOnce(delay.millis)(poll(requestNameString, queueName, session, requestStart, deadline))
+        }
     }
   }
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/action/ConsumeBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/ConsumeBuilder.scala
@@ -20,6 +20,7 @@ case class ConsumeBuilder(attributes: ConsumeAttributes, configuration: GatlingC
     new Consume(
       attributes,
       amqpComponents,
+      coreComponents.actorSystem.scheduler,
       coreComponents.statsEngine,
       coreComponents.clock,
       next,

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
@@ -15,11 +15,13 @@ case class RequestReplyDslBuilderMessage(
     configuration: GatlingConfiguration,
 ) {
 
-  /** Add a reply queue
+  /** Set the reply queue where the plugin listens for responses.
     */
   def replyExchange(name: Expression[String]): RequestReplyDslBuilderMessage = replyDestination(AmqpQueueExchange(name))
   private def replyDestination(destination: AmqpExchange)                    = this.copy(replyDest = destination)
-  def noReplyTo: RequestReplyDslBuilderMessage                               = this.copy(setReplyTo = false)
+
+  @deprecated("noReplyTo has no runtime effect — the AMQP replyTo property is not auto-set", "0.x")
+  def noReplyTo: RequestReplyDslBuilderMessage = this.copy(setReplyTo = false)
 
   def textMessage(text: Expression[String], charset: Charset = configuration.core.charset): RequestReplyDslBuilder =
     message(TextAmqpMessage(text, charset))

--- a/src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/Utils.kt
+++ b/src/test/kotlin/org/galaxio/gatling/amqp/javaapi/examples/Utils.kt
@@ -1,4 +1,9 @@
-package org.galaxio.gatling.javaapi.aqmp.examples
+package org.galaxio.gatling.amqp.javaapi.examples
+
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Supplier
+import java.util.stream.Stream
 
 object Utils {
     private val counter = AtomicInteger(1)

--- a/src/test/scala/io/gatling/amqp/testkit/CapturingStatsEngine.scala
+++ b/src/test/scala/io/gatling/amqp/testkit/CapturingStatsEngine.scala
@@ -1,0 +1,43 @@
+package io.gatling.amqp.testkit
+
+import io.gatling.commons.stats.Status
+import io.gatling.core.actor.ActorRef
+import io.gatling.core.controller.Controller
+import io.gatling.core.session.GroupBlock
+import io.gatling.core.stats.StatsEngine
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+/** Test double that captures the single logResponse a request action emits and signals completion via a latch.
+  *
+  * Lives in an `io.gatling`-rooted package so the package-private `Controller.Command` type referenced by [[StatsEngine.stop]]
+  * can be named when implementing the trait.
+  */
+final class CapturingStatsEngine extends StatsEngine {
+  val latch: CountDownLatch                    = new CountDownLatch(1)
+  val status: AtomicReference[Status]          = new AtomicReference[Status]()
+  val message: AtomicReference[Option[String]] = new AtomicReference[Option[String]](None)
+
+  override def logResponse(
+      scenario: String,
+      groups: List[String],
+      requestName: String,
+      startTimestamp: Long,
+      endTimestamp: Long,
+      st: Status,
+      responseCode: Option[String],
+      msg: Option[String],
+  ): Unit = {
+    status.set(st)
+    message.set(msg)
+    latch.countDown()
+  }
+
+  override def start(): Unit                                                                                     = ()
+  override def stop(controller: ActorRef[Controller.Command], exception: Option[Exception]): Unit                = ()
+  override def logUserStart(scenario: String): Unit                                                              = ()
+  override def logUserEnd(scenario: String): Unit                                                                = ()
+  override def logGroupEnd(scenario: String, group: GroupBlock, exitTimestamp: Long): Unit                       = ()
+  override def logRequestCrash(scenario: String, groups: List[String], requestName: String, error: String): Unit = ()
+}

--- a/src/test/scala/org/galaxio/gatling/amqp/integration/ConsumeTimeoutIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/integration/ConsumeTimeoutIntegrationSpec.scala
@@ -1,0 +1,170 @@
+package org.galaxio.gatling.amqp.integration
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, RabbitMQContainer}
+import com.rabbitmq.client.ConnectionFactory
+import io.gatling.amqp.testkit.CapturingStatsEngine
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.util.DefaultClock
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.session.Session
+import org.galaxio.gatling.amqp.AmqpCheck
+import org.galaxio.gatling.amqp.Predef.simpleCheck
+import org.galaxio.gatling.amqp.client.AmqpConnectionPool
+import org.galaxio.gatling.amqp.protocol.AmqpComponents
+import org.galaxio.gatling.amqp.request.ConsumeAttributes
+import org.galaxio.gatling.amqp.action.Consume
+import org.galaxio.gatling.amqp.tags.DockerTest
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+class ConsumeTimeoutIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestContainer with BeforeAndAfterAll {
+
+  override val container: RabbitMQContainer = RabbitMQContainer(
+    DockerImageName.parse("rabbitmq:3.13-management-alpine"),
+  )
+
+  private lazy val connectionFactory = {
+    val cf = new ConnectionFactory()
+    cf.setHost(container.host)
+    cf.setPort(container.amqpPort)
+    cf.setUsername(container.adminUsername)
+    cf.setPassword(container.adminPassword)
+    cf
+  }
+
+  private val clock           = new DefaultClock
+  private lazy val system     = new ActorSystem
+  private lazy val eventLoops = new io.netty.channel.nio.NioEventLoopGroup(1)
+
+  override def afterAll(): Unit = {
+    system.close()
+    eventLoops.shutdownGracefully()
+    super.afterAll()
+  }
+
+  private def terminalAction(onSession: Session => Unit): Action = new Action {
+    override def name: String                    = "test-terminal"
+    override def execute(session: Session): Unit = onSession(session)
+  }
+
+  private def newSession(): Session = Session("test-scenario", 0L, eventLoops.next())
+
+  /** Drives a Consume action against the real broker. Returns a latch that fires when the action advances to `next`. */
+  private def runConsume(
+      pool: AmqpConnectionPool,
+      queue: String,
+      timeout: Long,
+      stats: CapturingStatsEngine,
+      checks: List[AmqpCheck] = Nil,
+      silent: Boolean = false,
+  ): CountDownLatch = {
+    val advanced   = new CountDownLatch(1)
+    val expr       = (_: Session) => io.gatling.commons.validation.Success(queue)
+    val components = AmqpComponents(null, pool, null, null) // only connectionPublishPool is read by Consume
+    val consume    = new Consume(
+      ConsumeAttributes(expr, expr, timeout, checks, silent),
+      components,
+      system.scheduler,
+      stats,
+      clock,
+      terminalAction(_ => advanced.countDown()),
+      None,
+    )
+    consume.execute(newSession())
+    advanced
+  }
+
+  "Consume action timeout" should {
+    "fail with a timeout message when the queue stays empty" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 1, 4)
+      try {
+        declareQueue("consume_empty")
+        val stats = new CapturingStatsEngine
+        runConsume(pool, "consume_empty", 500L, stats)
+
+        stats.latch.await(5, TimeUnit.SECONDS) shouldBe true
+        stats.status.get() shouldBe KO
+        stats.message.get().exists(_.contains("No message in queue within 500ms")) shouldBe true
+      } finally pool.close()
+    }
+
+    "succeed when a message is already present" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 1, 4)
+      try {
+        declareQueue("consume_present")
+        publish("consume_present", "ready")
+        val stats = new CapturingStatsEngine
+        runConsume(pool, "consume_present", 2000L, stats)
+
+        stats.latch.await(5, TimeUnit.SECONDS) shouldBe true
+        stats.status.get() shouldBe OK
+      } finally pool.close()
+    }
+
+    "pick up a message that arrives mid-timeout without losing it" taggedAs DockerTest in {
+      val pool      = new AmqpConnectionPool(connectionFactory, 1, 4)
+      val publisher = new Thread(() => {
+        Thread.sleep(300)
+        publish("consume_delayed", "late")
+      })
+      try {
+        declareQueue("consume_delayed")
+        publisher.start()
+
+        val stats = new CapturingStatsEngine
+        runConsume(pool, "consume_delayed", 3000L, stats)
+
+        stats.latch.await(5, TimeUnit.SECONDS) shouldBe true
+        stats.status.get() shouldBe OK
+      } finally {
+        publisher.join()
+        pool.close()
+      }
+    }
+
+    "fail the check when the received message does not match" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 1, 4)
+      try {
+        declareQueue("consume_check")
+        publish("consume_check", "actual")
+        val stats = new CapturingStatsEngine
+        runConsume(pool, "consume_check", 2000L, stats, checks = List(simpleCheck(_ => false)))
+
+        stats.latch.await(5, TimeUnit.SECONDS) shouldBe true
+        stats.status.get() shouldBe KO
+      } finally pool.close()
+    }
+
+    "advance without logging a response when silent" taggedAs DockerTest in {
+      val pool = new AmqpConnectionPool(connectionFactory, 1, 4)
+      try {
+        declareQueue("consume_silent")
+        publish("consume_silent", "ready")
+        val stats    = new CapturingStatsEngine
+        val advanced = runConsume(pool, "consume_silent", 2000L, stats, silent = true)
+
+        advanced.await(5, TimeUnit.SECONDS) shouldBe true            // action still advances to next
+        stats.latch.await(500, TimeUnit.MILLISECONDS) shouldBe false // but no response was logged
+      } finally pool.close()
+    }
+  }
+
+  private def declareQueue(name: String): Unit           = withChannel(_.queueDeclare(name, false, false, true, null))
+  private def publish(queue: String, body: String): Unit =
+    withChannel(_.basicPublish("", queue, null, body.getBytes))
+
+  private def withChannel(f: com.rabbitmq.client.Channel => Unit): Unit = {
+    val conn    = connectionFactory.newConnection()
+    val channel = conn.createChannel()
+    try f(channel)
+    finally {
+      channel.close()
+      conn.close()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses three documentation-labeled issues in a single PR with separate commits:

- **#28** — Fix Kotlin `Utils.kt` (wrong package `aqmp` → `amqp`, missing imports). Add README note that Kotlin examples are reference-only (not CI-compiled). Add missing `RequestReplyWithOwnMatchingExample.kt` link.
- **#26** — Implement polling with timeout in `Consume` action. Previously `basicGet` was a single-shot call ignoring the `.timeout()` DSL option. Now polls every 100ms until a message arrives or timeout expires.
- **#25** — Fix README `replyExchange` example (showed 2 args, actual signature takes 1). Document that reply routing is always queue-based. Deprecate `noReplyTo` in Scala/Java APIs since it has no runtime effect.

## Changes

- `src/test/kotlin/.../Utils.kt` — fixed package name and added missing imports
- `README.md` — corrected Kotlin section, consume docs, and request-reply docs
- `src/main/scala/.../Consume.scala` — added polling loop with configurable timeout
- `src/main/scala/.../RequestReplyDslBuilderMessage.scala` — deprecated `noReplyTo`
- `src/main/java/.../RequestReplyDslBuilderMessage.java` — deprecated `noReplyTo`

## Test plan

- [x] All 98 unit + integration tests pass on each commit
- [x] `sbt scalafmtAll` applied
- [x] No public API removed (backward compatible)

Fixes #28, fixes #26, fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)