### PR TITLE
docs: make quick start self-contained with broker setup and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Alternatively, let the plugin declare the queue automatically — see [Queue and
 
 ### 3. Run the simulation
 
-### Minimal Scenario — Scala
+#### Scala
 
 ```scala
 import org.galaxio.gatling.amqp.Predef._
@@ -116,7 +116,7 @@ class AmqpSimulation extends Simulation {
 }
 ```
 
-### Minimal Scenario — Java
+#### Java
 
 ```java
 import static org.galaxio.gatling.amqp.javaapi.AmqpDsl.*;
@@ -142,7 +142,7 @@ public class AmqpSimulation extends Simulation {
 }
 ```
 
-### Minimal Scenario — Kotlin
+#### Kotlin
 
 ```kotlin
 import org.galaxio.gatling.amqp.javaapi.AmqpDsl.*
@@ -173,7 +173,10 @@ class AmqpSimulation : Simulation() {
 After the simulation completes, confirm the message arrived in the queue:
 
 ```bash
-# Check queue message count (should be 1 for atOnceUsers(1))
+# Purge any old messages first, then run the simulation
+docker exec gatling-rabbit rabbitmqadmin purge queue name=test-queue
+
+# After the test, check the queue
 docker exec gatling-rabbit rabbitmqadmin get queue=test-queue count=10
 ```
 
@@ -183,7 +186,7 @@ You can also verify via the management UI at <http://localhost:15672/#/queues/%2
 
 ### 5. Request-Reply walkthrough
 
-A request-reply test publishes a message and waits for a response on a reply queue. For a quick local verification, start a simple consumer that echoes messages back:
+A request-reply test publishes a message and waits for a response on a reply queue.
 
 ```bash
 # Create the request and reply queues
@@ -191,11 +194,36 @@ docker exec gatling-rabbit rabbitmqadmin declare queue name=request-queue durabl
 docker exec gatling-rabbit rabbitmqadmin declare queue name=reply-queue durable=false
 ```
 
-Then run a tiny consumer (Python with pika, or any AMQP client) that reads from `request-queue` and publishes the reply to the queue specified in the message's `replyTo` property. For manual testing, you can use the [RabbitMQ Shovel plugin](https://www.rabbitmq.com/shovel.html) or a simple script.
+Start a simple echo consumer that reads from `request-queue` and replies to the queue in the message's `replyTo` property:
+
+```bash
+# Python echo consumer (requires pika: pip install pika)
+docker exec -d gatling-rabbit bash -c '
+pip install pika -q && python3 -c "
+import pika, json
+conn = pika.BlockingConnection(pika.ConnectionParameters(\"localhost\"))
+ch = conn.channel()
+def on_msg(channel, method, props, body):
+    ch.basic_publish(exchange=\"\", routing_key=props.reply_to,
+                     properties=pika.BasicProperties(correlation_id=props.message_id),
+                     body=body)
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+ch.basic_consume(queue=\"request-queue\", on_message_callback=on_msg)
+ch.start_consuming()
+"'
+```
 
 Scala simulation:
 
 ```scala
+val amqpConf = amqp
+  .connectionFactory(
+    rabbitmq.host("localhost").port(5672).username("guest").password("guest").vhost("/")
+  )
+  .replyTimeout(60000)
+  .consumerThreadsCount(8)
+  .matchByMessageId
+
 val scn = scenario("Request-Reply")
   .exec(
     amqp("rpc-call").requestReply
@@ -209,7 +237,7 @@ val scn = scenario("Request-Reply")
 setUp(scn.inject(atOnceUsers(1))).protocols(amqpConf)
 ```
 
-If no consumer is running, the request will time out (default 30 s) and Gatling reports a failure — this confirms the round-trip is wired correctly.
+If no consumer is running, the request will time out (default 60 s per `replyTimeout`) and Gatling reports a KO — this confirms the round-trip is wired correctly.
 
 ## Protocol Configuration
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,31 @@ gatling("org.galaxio:gatling-amqp-plugin_2.13:<version>")
 
 ## Quick Start
 
-### Docker (local RabbitMQ)
+### Prerequisites
+
+You need a running RabbitMQ instance. The examples below use `queueExchange("test-queue")`, which publishes directly to the default exchange with routing key `test-queue`. **The queue must exist before the test runs** — otherwise messages are silently dropped.
+
+### 1. Start RabbitMQ
 
 ```bash
 docker run -d --name gatling-rabbit \
   -p 5672:5672 -p 15672:15672 \
   rabbitmq:3-management
 ```
+
+The management UI is available at <http://localhost:15672> (guest/guest).
+
+### 2. Create the required queue
+
+Using the management CLI inside the container:
+
+```bash
+docker exec gatling-rabbit rabbitmqadmin declare queue name=test-queue durable=false
+```
+
+Alternatively, let the plugin declare the queue automatically — see [Queue and Exchange Declarations](#queue-and-exchange-declarations) below.
+
+### 3. Run the simulation
 
 ### Minimal Scenario — Scala
 
@@ -149,6 +167,49 @@ class AmqpSimulation : Simulation() {
   init { setUp(scn.injectOpen(atOnceUsers(1)).protocols(amqpConf)) }
 }
 ```
+
+### 4. Verify it worked
+
+After the simulation completes, confirm the message arrived in the queue:
+
+```bash
+# Check queue message count (should be 1 for atOnceUsers(1))
+docker exec gatling-rabbit rabbitmqadmin get queue=test-queue count=10
+```
+
+You should see the JSON payload `{"msg": "hello"}` in the output. If the queue was empty, the message was likely routed to a non-existent queue (check spelling) or the queue was not declared before the test.
+
+You can also verify via the management UI at <http://localhost:15672/#/queues/%2F/test-queue> — click "Get messages" to inspect the content.
+
+### 5. Request-Reply walkthrough
+
+A request-reply test publishes a message and waits for a response on a reply queue. For a quick local verification, start a simple consumer that echoes messages back:
+
+```bash
+# Create the request and reply queues
+docker exec gatling-rabbit rabbitmqadmin declare queue name=request-queue durable=false
+docker exec gatling-rabbit rabbitmqadmin declare queue name=reply-queue durable=false
+```
+
+Then run a tiny consumer (Python with pika, or any AMQP client) that reads from `request-queue` and publishes the reply to the queue specified in the message's `replyTo` property. For manual testing, you can use the [RabbitMQ Shovel plugin](https://www.rabbitmq.com/shovel.html) or a simple script.
+
+Scala simulation:
+
+```scala
+val scn = scenario("Request-Reply")
+  .exec(
+    amqp("rpc-call").requestReply
+      .queueExchange("request-queue")
+      .replyExchange("reply-queue")
+      .textMessage("""{"action": "ping"}""")
+      .contentType("application/json")
+      .check(bodyString.exists)
+  )
+
+setUp(scn.inject(atOnceUsers(1))).protocols(amqpConf)
+```
+
+If no consumer is running, the request will time out (default 30 s) and Gatling reports a failure — this confirms the round-trip is wired correctly.
 
 ## Protocol Configuration
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ gatling("org.galaxio:gatling-amqp-plugin_2.13:<version>")
 
 ### Prerequisites
 
-You need a running RabbitMQ instance. The examples below use `queueExchange("test-queue")`, which publishes directly to the default exchange with routing key `test-queue`. **The queue must exist before the test runs** — otherwise messages are silently dropped.
+You need a running RabbitMQ instance. The examples below use `queueExchange("test-queue")`, which publishes directly to the default exchange with routing key `test-queue`. **The queue must exist before the test runs** — otherwise messages are discarded by the broker (no error is reported to the publisher).
 
 ### 1. Start RabbitMQ
 
@@ -170,17 +170,17 @@ class AmqpSimulation : Simulation() {
 
 ### 4. Verify it worked
 
-After the simulation completes, confirm the message arrived in the queue:
+Purge stale messages, run the simulation, then check:
 
 ```bash
-# Purge any old messages first, then run the simulation
+# Before the test — clear any leftover messages
 docker exec gatling-rabbit rabbitmqadmin purge queue name=test-queue
 
-# After the test, check the queue
+# Run the simulation (step 3), then inspect:
 docker exec gatling-rabbit rabbitmqadmin get queue=test-queue count=10
 ```
 
-You should see the JSON payload `{"msg": "hello"}` in the output. If the queue was empty, the message was likely routed to a non-existent queue (check spelling) or the queue was not declared before the test.
+You should see the JSON payload `{"msg": "hello"}` in the output. If the queue is empty, the message was routed to a non-existent queue (check spelling) or the queue was not declared before the test.
 
 You can also verify via the management UI at <http://localhost:15672/#/queues/%2F/test-queue> — click "Get messages" to inspect the content.
 
@@ -194,28 +194,34 @@ docker exec gatling-rabbit rabbitmqadmin declare queue name=request-queue durabl
 docker exec gatling-rabbit rabbitmqadmin declare queue name=reply-queue durable=false
 ```
 
-Start a simple echo consumer that reads from `request-queue` and replies to the queue in the message's `replyTo` property:
+Start a simple echo consumer on your host (requires Python 3 and `pip install pika`):
 
 ```bash
-# Python echo consumer (requires pika: pip install pika)
-docker exec -d gatling-rabbit bash -c '
-pip install pika -q && python3 -c "
-import pika, json
-conn = pika.BlockingConnection(pika.ConnectionParameters(\"localhost\"))
+# echo_consumer.py — reads from request-queue, replies to the replyTo queue
+python3 -c "
+import pika
+conn = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
 ch = conn.channel()
 def on_msg(channel, method, props, body):
-    ch.basic_publish(exchange=\"\", routing_key=props.reply_to,
+    ch.basic_publish(exchange='', routing_key=props.reply_to,
                      properties=pika.BasicProperties(correlation_id=props.message_id),
                      body=body)
     ch.basic_ack(delivery_tag=method.delivery_tag)
-ch.basic_consume(queue=\"request-queue\", on_message_callback=on_msg)
+    print(f'Replied to {props.reply_to}')
+ch.basic_consume(queue='request-queue', on_message_callback=on_msg)
+print('Waiting for messages on request-queue...')
 ch.start_consuming()
-"'
+" &
 ```
+
+> Run the consumer in a separate terminal (or background with `&` as shown). After the test you can stop it with `kill %1`.
 
 Scala simulation:
 
 ```scala
+import org.galaxio.gatling.amqp.Predef._
+import io.gatling.core.Predef._
+
 val amqpConf = amqp
   .connectionFactory(
     rabbitmq.host("localhost").port(5672).username("guest").password("guest").vhost("/")


### PR DESCRIPTION
## Summary

Makes the quick start section self-contained so a new user can copy it into a clean RabbitMQ container and see a successful outcome.

## Changes

- Add explicit prerequisites noting that `test-queue` must exist before the test
- Number the quick start steps (1-5) for clarity
- Add queue creation command using `rabbitmqadmin`
- Add "how to verify it worked" section with CLI and management UI instructions
- Add request-reply walkthrough with queue setup and example scenario

## Testing

- Verified README renders correctly
- Instructions are self-contained and explicit

Fixes galax-io/gatling-amqp-plugin#18