### PR TITLE
feat: support protocol init actions on reply broker in two-broker mode

### DIFF
--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/AmqpProtocolBuilder.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/protocol/AmqpProtocolBuilder.java
@@ -115,6 +115,55 @@ public class AmqpProtocolBuilder implements ProtocolBuilder{
         return this;
     }
 
+    public AmqpProtocolBuilder replyDeclare(AmqpQueue q) {
+        this.wrapped = wrapped.replyDeclare(org.galaxio.gatling.amqp.Predef.queue(
+                q.getName(),
+                q.getDurable(),
+                q.getExclusive(),
+                q.getAutoDelete(),
+                scala.collection.immutable.Map.from(asScala(q.getArguments()))
+        ));
+        return this;
+    }
+
+    public AmqpProtocolBuilder replyDeclare(AmqpExchange e) {
+        this.wrapped = wrapped.replyDeclare(org.galaxio.gatling.amqp.Predef.exchange(
+                e.getName(),
+                e.getExchangeType(),
+                e.getDurable(),
+                e.getAutoDelete(),
+                scala.collection.immutable.Map.from(asScala(e.getArguments()))
+        ));
+        return this;
+    }
+
+    public AmqpProtocolBuilder replyBindQueue(
+            AmqpQueue q,
+            AmqpExchange e,
+            String routingKey,
+            Map<String, Object> args
+    ) {
+        this.wrapped = wrapped.replyBindQueue(
+                org.galaxio.gatling.amqp.Predef.queue(
+                        q.getName(),
+                        q.getDurable(),
+                        q.getExclusive(),
+                        q.getAutoDelete(),
+                        scala.collection.immutable.Map.from(asScala(q.getArguments()))
+                ),
+                org.galaxio.gatling.amqp.Predef.exchange(
+                        e.getName(),
+                        e.getExchangeType(),
+                        e.getDurable(),
+                        e.getAutoDelete(),
+                        scala.collection.immutable.Map.from(asScala(e.getArguments()))
+                ),
+                routingKey,
+                scala.collection.immutable.Map.from(asScala(args))
+        );
+        return this;
+    }
+
     @Override
     public Protocol protocol() {
         return wrapped.build();

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocol.scala
@@ -58,6 +58,17 @@ object AmqpProtocol {
           requestPool.returnChannel(ch)
         }
 
+        if (amqpProtocol.replyInitActions.nonEmpty) {
+          val ch = replyPool.channel
+          try amqpProtocol.replyInitActions.foreach(runInitAction(ch))
+          catch {
+            case e: Exception =>
+              replyPool.invalidate(ch)
+              throw e
+          }
+          replyPool.returnChannel(ch)
+        }
+
         val trackerPool = new TrackerPool(
           replyPool,
           coreComponents.actorSystem,
@@ -80,6 +91,7 @@ case class AmqpProtocol(
     messageMatcher: AmqpMessageMatcher,
     responseTransformer: Option[AmqpProtocolMessage => AmqpProtocolMessage],
     initActions: AmqpChannelInitActions,
+    replyInitActions: AmqpChannelInitActions = Nil,
     channelPoolSize: Int = 16,
     publisherConfirms: Boolean = false,
 ) extends Protocol {

--- a/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilder.scala
@@ -12,6 +12,7 @@ case class AmqpProtocolBuilder(
     replyTimeout: Option[Long] = None,
     responseTransformer: Option[AmqpProtocolMessage => AmqpProtocolMessage] = None,
     initActions: AmqpChannelInitActions = Nil,
+    replyInitActions: AmqpChannelInitActions = Nil,
     channelPoolSize: Int = 16,
     publisherConfirms: Boolean = false,
 ) {
@@ -50,6 +51,18 @@ case class AmqpProtocolBuilder(
   ): AmqpProtocolBuilder =
     this.copy(initActions = this.initActions :+ BindQueue(q.name, e.name, routingKey, args))
 
+  def replyDeclare(q: AmqpQueue): AmqpProtocolBuilder    = this.copy(replyInitActions = this.replyInitActions :+ QueueDeclare(q))
+  def replyDeclare(e: AmqpExchange): AmqpProtocolBuilder =
+    this.copy(replyInitActions = this.replyInitActions :+ ExchangeDeclare(e))
+
+  def replyBindQueue(
+      q: AmqpQueue,
+      e: AmqpExchange,
+      routingKey: String,
+      args: Map[String, Any] = Map.empty,
+  ): AmqpProtocolBuilder =
+    this.copy(replyInitActions = this.replyInitActions :+ BindQueue(q.name, e.name, routingKey, args))
+
   def build: AmqpProtocol =
     AmqpProtocol(
       requestConnectionFactory,
@@ -60,6 +73,7 @@ case class AmqpProtocolBuilder(
       messageMatcher,
       responseTransformer,
       initActions,
+      replyInitActions,
       channelPoolSize,
       publisherConfirms,
     )

--- a/src/test/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/protocol/AmqpProtocolBuilderSpec.scala
@@ -21,6 +21,7 @@ class AmqpProtocolBuilderSpec extends AnyFlatSpec with Matchers {
     builder.replyTimeout shouldBe None
     builder.responseTransformer shouldBe None
     builder.initActions shouldBe Nil
+    builder.replyInitActions shouldBe Nil
   }
 
   it should "set persistent delivery mode" in {
@@ -155,5 +156,71 @@ class AmqpProtocolBuilderSpec extends AnyFlatSpec with Matchers {
     val builder = defaultBuilder.bindQueue(q, e, "rk", args)
 
     builder.initActions.head shouldBe BindQueue("q1", "e1", "rk", args)
+  }
+
+  it should "append QueueDeclare to replyInitActions when declaring a reply queue" in {
+    val q       = AmqpQueue("reply-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.replyDeclare(q)
+
+    builder.replyInitActions should have size 1
+    builder.replyInitActions.head shouldBe QueueDeclare(q)
+    builder.initActions shouldBe Nil
+  }
+
+  it should "append ExchangeDeclare to replyInitActions when declaring a reply exchange" in {
+    val e       =
+      AmqpExchange("reply-exchange", BuiltinExchangeType.TOPIC, durable = true, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.replyDeclare(e)
+
+    builder.replyInitActions should have size 1
+    builder.replyInitActions.head shouldBe ExchangeDeclare(e)
+    builder.initActions shouldBe Nil
+  }
+
+  it should "append BindQueue to replyInitActions when binding a reply queue" in {
+    val q       = AmqpQueue("reply-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val e       = AmqpExchange("reply-exchange", BuiltinExchangeType.TOPIC, durable = true, autoDelete = false, arguments = Map.empty)
+    val builder = defaultBuilder.replyBindQueue(q, e, "reply.key")
+
+    builder.replyInitActions should have size 1
+    builder.replyInitActions.head shouldBe BindQueue("reply-queue", "reply-exchange", "reply.key", Map.empty)
+    builder.initActions shouldBe Nil
+  }
+
+  it should "keep request and reply init actions separate" in {
+    val reqQ   = AmqpQueue("req-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val replyQ = AmqpQueue("reply-queue", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val e      = AmqpExchange("e1", BuiltinExchangeType.DIRECT, durable = true, autoDelete = false, arguments = Map.empty)
+
+    val builder = defaultBuilder
+      .declare(reqQ)
+      .declare(e)
+      .replyDeclare(replyQ)
+      .replyDeclare(e)
+      .replyBindQueue(replyQ, e, "reply.rk")
+
+    builder.initActions should have size 2
+    builder.initActions(0) shouldBe QueueDeclare(reqQ)
+    builder.initActions(1) shouldBe ExchangeDeclare(e)
+
+    builder.replyInitActions should have size 3
+    builder.replyInitActions(0) shouldBe QueueDeclare(replyQ)
+    builder.replyInitActions(1) shouldBe ExchangeDeclare(e)
+    builder.replyInitActions(2) shouldBe BindQueue("reply-queue", "e1", "reply.rk", Map.empty)
+  }
+
+  it should "build an AmqpProtocol with replyInitActions preserved" in {
+    val q      = AmqpQueue("q1", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+    val replyQ = AmqpQueue("reply-q1", durable = true, exclusive = false, autoDelete = false, arguments = Map.empty)
+
+    val protocol = defaultBuilder
+      .declare(q)
+      .replyDeclare(replyQ)
+      .build
+
+    protocol.initActions should have size 1
+    protocol.initActions.head shouldBe QueueDeclare(q)
+    protocol.replyInitActions should have size 1
+    protocol.replyInitActions.head shouldBe QueueDeclare(replyQ)
   }
 }


### PR DESCRIPTION
## Summary

- Add `replyDeclare(queue)`, `replyDeclare(exchange)`, and `replyBindQueue(queue, exchange, routingKey)` DSL methods to `AmqpProtocolBuilder`, enabling declarative queue/exchange setup against the reply broker in two-broker request-reply topologies
- Reply init actions execute on the reply connection pool during protocol startup, parallel to existing request-side init actions
- Updated both Scala DSL and Java API with the new methods

## Changes

| File | Change |
|------|--------|
| `AmqpProtocolBuilder.scala` | Added `replyInitActions` field + `replyDeclare`/`replyBindQueue` methods |
| `AmqpProtocol.scala` | Added `replyInitActions` field + execution block on `replyPool` |
| `AmqpProtocolBuilder.java` | Added `replyDeclare`/`replyBindQueue` Java API methods |
| `AmqpProtocolBuilderSpec.scala` | Added 5 unit tests for new builder methods |

## Backward compatibility

- `replyInitActions` defaults to `Nil`, so existing configurations are unaffected
- Existing `declare()` and `bindQueue()` methods remain unchanged

## Test plan

- [x] Unit tests for `replyDeclare(queue)` appends to `replyInitActions`
- [x] Unit tests for `replyDeclare(exchange)` appends to `replyInitActions`
- [x] Unit tests for `replyBindQueue` appends to `replyInitActions`
- [x] Test that request and reply init actions stay separate
- [x] Test that `build` preserves `replyInitActions` in protocol
- [x] All 22 tests pass (17 existing + 5 new)
- [x] Compilation verified for both Scala and Java sources

Fixes #23