### PR TITLE
fix: tighten CI permissions and add dependency review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: read
-  checks: write
-  pull-requests: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -45,10 +41,23 @@ jobs:
       - name: Scalafmt Check
         run: sbt scalafmtCheckAll scalafmtSbtCheck
 
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+
   test:
     name: Test (Java ${{ matrix.java }})
     runs-on: ubuntu-24.04
     needs: [format]
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: ['17', '21']


### PR DESCRIPTION
## Summary
- Restrict top-level workflow permissions in `ci.yml` to `contents: read`, removing unused `actions: read`, `pull-requests: write`, and `packages: write`
- Add per-job `permissions` block to `test` job (`checks: write` for test reporting); `release` job already had its own block
- Add `dependency-review` job that runs `actions/dependency-review-action@v4` on pull requests for supply chain security checks

## Test plan
- [ ] Verify `format` job still passes (read-only permissions sufficient)
- [ ] Verify `test` job still passes with `checks: write` for test reporting
- [ ] Verify `dependency-review` job runs on this PR
- [ ] Verify `release` job permissions are unchanged

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)