### PR TITLE
fix: remove unused selector field and dead Dest types

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/AmqpDsl.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/AmqpDsl.scala
@@ -6,12 +6,6 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.session.Expression
 import org.galaxio.gatling.amqp.checks.AmqpCheckSupport
-import org.galaxio.gatling.amqp.protocol.{
-  AmqpProtocol,
-  AmqpProtocolBuilder,
-  AmqpProtocolBuilderBase,
-  RabbitMQConnectionFactoryBuilder,
-}
 import org.galaxio.gatling.amqp.request.{AmqpDslBuilderBase, ConsumeDslBuilder, PublishDslBuilder, RequestReplyDslBuilder}
 
 trait AmqpDsl extends AmqpCheckSupport {

--- a/src/main/scala/org/galaxio/gatling/amqp/action/package.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/package.scala
@@ -12,7 +12,4 @@ package object action {
     }
   }
 
-  sealed trait Dest
-  case class DirectDest(exchName: String, rk: String) extends Dest
-  case class QueueDest(qName: String)                 extends Dest
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/AmqpAttributes.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/AmqpAttributes.scala
@@ -6,7 +6,6 @@ import org.galaxio.gatling.amqp.AmqpCheck
 case class AmqpAttributes(
     requestName: Expression[String],
     destination: AmqpExchange,
-    selector: Option[String],
     message: AmqpMessage,
     messageProperties: AmqpMessageProperties = AmqpMessageProperties(),
     checks: List[AmqpCheck] = Nil,

--- a/src/main/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderMessage.scala
@@ -19,7 +19,7 @@ case class PublishDslBuilderMessage(
 
   private def message(mess: AmqpMessage) =
     PublishDslBuilder(
-      AmqpAttributes(requestName, destination, None, mess),
+      AmqpAttributes(requestName, destination, mess),
       PublishBuilder(_, configuration),
     )
 

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderExchange.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderExchange.scala
@@ -19,7 +19,6 @@ case class RequestReplyDslBuilderExchange(requestName: Expression[String], confi
       dest,
       AmqpQueueExchange(""),
       setReplyTo = false,
-      None,
       configuration,
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
@@ -30,7 +30,7 @@ case class RequestReplyDslBuilderMessage(
 
   private def message(mess: AmqpMessage) =
     RequestReplyDslBuilder(
-      AmqpAttributes(requestName, destination, messageSelector, mess),
+      AmqpAttributes(requestName, destination, mess),
       RequestReplyBuilder(_, replyDest, setReplyTo, configuration),
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
@@ -11,7 +11,6 @@ case class RequestReplyDslBuilderMessage(
     destination: AmqpExchange,
     replyDest: AmqpExchange,
     setReplyTo: Boolean,
-    messageSelector: Option[String],
     configuration: GatlingConfiguration,
 ) {
 

--- a/src/test/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/amqp/request/PublishDslBuilderSpec.scala
@@ -42,7 +42,6 @@ class PublishDslBuilderSpec extends AnyFlatSpec with Matchers {
   private def defaultAttrs: AmqpAttributes = AmqpAttributes(
     requestName = requestName,
     destination = dummyExchange,
-    selector = None,
     message = dummyMessage,
   )
 


### PR DESCRIPTION
## Summary

- Remove `selector: Option[String]` from `AmqpAttributes` (never read by any action class)
- Remove unused `Dest`/`DirectDest`/`QueueDest` sealed trait from `action` package object
- Clean up redundant explicit imports in `AmqpDsl` already covered by wildcard import

## Changes

- `AmqpAttributes.scala` — removed dead `selector` field
- `action/package.scala` — removed dead `Dest` ADT
- `AmqpDsl.scala` — removed redundant explicit imports
- `PublishDslBuilderMessage.scala`, `RequestReplyDslBuilderMessage.scala`, `PublishDslBuilderSpec.scala` — updated all `AmqpAttributes` construction sites

## Testing

- `sbt clean compile test` passes (133 tests, 0 failures)

Fixes #33