### PR TITLE
fix: improve error and timeout logging context

### DIFF
--- a/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/Publish.scala
@@ -40,7 +40,7 @@ class Publish(
       next ! session
     } catch {
       case e: Throwable =>
-        logger.error(e.getMessage, e)
+        logger.error(s"Failed to publish message for request '$requestNameString': ${e.getMessage}", e)
         if (!attributes.silent)
           statsEngine.logResponse(
             session.scenario,

--- a/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/RequestReply.scala
@@ -70,7 +70,7 @@ class RequestReply(
         } catch {
           case e: Throwable =>
             trackerPool.decrementPendingAndEvict(qName)
-            logger.error(e.getMessage, e)
+            logger.error(s"Failed to send request-reply for '$requestNameString' (reply queue: $qName): ${e.getMessage}", e)
             if (!attributes.silent)
               statsEngine.logResponse(
                 session.scenario,

--- a/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/AmqpMessageTrackerActor.scala
@@ -12,6 +12,8 @@ import org.galaxio.gatling.amqp.AmqpCheck
 import org.galaxio.gatling.amqp.client.AmqpMessageTrackerActor.{MessageConsumed, MessagePublished, TimeoutScan}
 import org.galaxio.gatling.amqp.request.AmqpProtocolMessage
 
+import com.typesafe.scalalogging.StrictLogging
+
 import scala.collection.mutable
 import scala.concurrent.duration._
 
@@ -41,7 +43,7 @@ object AmqpMessageTrackerActor {
 }
 
 class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clock)
-    extends Actor[AmqpMessageTrackerActor.AmqpMessage](name) {
+    extends Actor[AmqpMessageTrackerActor.AmqpMessage](name) with StrictLogging {
 
   private val sentMessages                 = mutable.HashMap.empty[String, MessagePublished]
   private val timedOutMessages             = mutable.ArrayBuffer.empty[MessagePublished]
@@ -67,10 +69,12 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
     // message was received; publish stats and remove from the map
     case MessageConsumed(matchId, received, message) =>
       // if key is missing, message was already acked and is a dup, or request timeout
-      sentMessages.remove(matchId).foreach {
-        case MessagePublished(_, sent, _, checks, session, next, requestName, silent, onComplete) =>
+      sentMessages.remove(matchId) match {
+        case Some(MessagePublished(_, sent, _, checks, session, next, requestName, silent, onComplete)) =>
           processMessage(session, sent, received, checks, message, next, requestName, silent)
           onComplete.foreach(_())
+        case None                                                                                       =>
+          logger.debug(s"Received reply for unknown or already-handled matchId: $matchId")
       }
       stay
 
@@ -84,9 +88,11 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
       }
 
       for (
-        MessagePublished(matchId, sent, receivedTimeout, _, session, next, requestName, silent, onComplete) <- timedOutMessages
+        MessagePublished(matchId, sent, replyTimeout, _, session, next, requestName, silent, onComplete) <- timedOutMessages
       ) {
+        val elapsed = now - sent
         sentMessages.remove(matchId)
+        logger.debug(s"Reply timeout for matchId=$matchId after ${elapsed}ms (request: $requestName)")
         executeNext(
           session.markAsFailed,
           sent,
@@ -95,7 +101,7 @@ class AmqpMessageTrackerActor(name: String, statsEngine: StatsEngine, clock: Clo
           next,
           requestName,
           None,
-          Some(s"Reply timeout after $receivedTimeout ms"),
+          Some(s"Reply timeout after ${elapsed}ms (limit: ${replyTimeout}ms)"),
           silent,
         )
         onComplete.foreach(_())

--- a/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/client/TrackerPool.scala
@@ -84,8 +84,12 @@ class TrackerPool(
     pendingCounts.remove(sourceQueue)
     Option(consumerEntries.remove(sourceQueue)).foreach { entries =>
       entries.foreach { case (channel, tag) =>
-        Try(channel.basicCancel(tag))
-        Try(channel.close())
+        Try(channel.basicCancel(tag)).recover { case e =>
+          logger.debug(s"Failed to cancel consumer $tag: ${e.getMessage}")
+        }
+        Try(channel.close()).recover { case e =>
+          logger.debug(s"Failed to close channel for consumer $tag: ${e.getMessage}")
+        }
       }
     }
   }
@@ -94,8 +98,12 @@ class TrackerPool(
     import scala.jdk.CollectionConverters._
     consumerEntries.values().asScala.foreach { entries =>
       entries.foreach { case (channel, tag) =>
-        Try(channel.basicCancel(tag))
-        Try(channel.close())
+        Try(channel.basicCancel(tag)).recover { case e =>
+          logger.debug(s"Failed to cancel consumer $tag: ${e.getMessage}")
+        }
+        Try(channel.close()).recover { case e =>
+          logger.debug(s"Failed to close channel for consumer $tag: ${e.getMessage}")
+        }
       }
     }
     consumerEntries.clear()


### PR DESCRIPTION
## Summary
- Add request name and routing context to error logs in `Publish` and `RequestReply` actions
- Fix timeout message in `AmqpMessageTrackerActor` to show actual elapsed time instead of only the configured limit
- Add debug-level logging for unmatched reply messages and periodic timeout scans
- Log consumer cleanup failures in `TrackerPool` at debug level instead of silently swallowing them

## Test plan
- [x] `sbt clean compile test` passes (133 tests)
- [x] No new dependencies introduced
- [x] All logging additions are at debug level (non-error) or improve existing error messages

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)