### PR TITLE
fix: close Java API parity gaps and remove dead noReplyTo

### DIFF
--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/PublishDslBuilderMessage.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/PublishDslBuilderMessage.java
@@ -16,4 +16,12 @@ public class PublishDslBuilderMessage {
     public PublishDslBuilder textMessage(String text, Charset charset){
         return new PublishDslBuilder(wrapped.textMessage(toStringExpression(text), charset));
     }
+
+    public PublishDslBuilder bytesMessage(byte[] bytes){
+        return new PublishDslBuilder(wrapped.bytesMessage(toStaticValueExpression(bytes)));
+    }
+
+    public PublishDslBuilder bytesMessage(String el){
+        return new PublishDslBuilder(wrapped.bytesMessage(toBytesExpression(el)));
+    }
 }

--- a/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilderMessage.java
+++ b/src/main/java/org/galaxio/gatling/amqp/javaapi/request/RequestReplyDslBuilderMessage.java
@@ -16,12 +16,6 @@ public class RequestReplyDslBuilderMessage {
         return this;
     }
 
-    @Deprecated
-    public RequestReplyDslBuilderMessage noReplyTo(){
-        this.wrapped = wrapped.noReplyTo();
-        return this;
-    }
-
     public RequestReplyDslBuilder textMessage(String text){
         return textMessage(text, io.gatling.core.Predef.configuration().core().charset());
     }

--- a/src/main/scala/org/galaxio/gatling/amqp/action/RequestReplyBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/action/RequestReplyBuilder.scala
@@ -12,7 +12,6 @@ import org.galaxio.gatling.amqp.request.AmqpAttributes
 case class RequestReplyBuilder(
     attributes: AmqpAttributes,
     replyDest: AmqpExchange,
-    setReplyTo: Boolean,
     configuration: GatlingConfiguration,
 ) extends ActionBuilder {
   private def components(protocolComponentsRegistry: ProtocolComponentsRegistry): AmqpComponents =

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderExchange.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderExchange.scala
@@ -18,7 +18,6 @@ case class RequestReplyDslBuilderExchange(requestName: Expression[String], confi
       requestName,
       dest,
       AmqpQueueExchange(""),
-      setReplyTo = false,
       configuration,
     )
 }

--- a/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
+++ b/src/main/scala/org/galaxio/gatling/amqp/request/RequestReplyDslBuilderMessage.scala
@@ -10,7 +10,6 @@ case class RequestReplyDslBuilderMessage(
     requestName: Expression[String],
     destination: AmqpExchange,
     replyDest: AmqpExchange,
-    setReplyTo: Boolean,
     configuration: GatlingConfiguration,
 ) {
 
@@ -18,9 +17,6 @@ case class RequestReplyDslBuilderMessage(
     */
   def replyExchange(name: Expression[String]): RequestReplyDslBuilderMessage = replyDestination(AmqpQueueExchange(name))
   private def replyDestination(destination: AmqpExchange)                    = this.copy(replyDest = destination)
-
-  @deprecated("noReplyTo has no runtime effect — the AMQP replyTo property is not auto-set", "0.x")
-  def noReplyTo: RequestReplyDslBuilderMessage = this.copy(setReplyTo = false)
 
   def textMessage(text: Expression[String], charset: Charset = configuration.core.charset): RequestReplyDslBuilder =
     message(TextAmqpMessage(text, charset))
@@ -30,6 +26,6 @@ case class RequestReplyDslBuilderMessage(
   private def message(mess: AmqpMessage) =
     RequestReplyDslBuilder(
       AmqpAttributes(requestName, destination, mess),
-      RequestReplyBuilder(_, replyDest, setReplyTo, configuration),
+      RequestReplyBuilder(_, replyDest, configuration),
     )
 }

--- a/src/test/java/org/galaxio/gatling/amqp/javaapi/examples/ConsumeExample.java
+++ b/src/test/java/org/galaxio/gatling/amqp/javaapi/examples/ConsumeExample.java
@@ -1,0 +1,45 @@
+package org.galaxio.gatling.amqp.javaapi.examples;
+
+import org.galaxio.gatling.amqp.javaapi.protocol.AmqpProtocolBuilder;
+import org.galaxio.gatling.amqp.javaapi.protocol.AmqpQueue;
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+
+import java.util.Map;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static org.galaxio.gatling.amqp.javaapi.AmqpDsl.*;
+
+public class ConsumeExample extends Simulation {
+
+    public AmqpProtocolBuilder amqpConf = amqp()
+            .connectionFactory(
+                    rabbitmq()
+                            .host("localhost")
+                            .port(5672)
+                            .username("guest")
+                            .password("guest")
+                            .vhost("/")
+                            .build()
+            )
+            .usePersistentDeliveryMode()
+            .declare(new AmqpQueue("test_queue", false, false, false, Map.of()));
+
+    public ScenarioBuilder scn = scenario("AMQP Consume test")
+            .exec(
+                    amqp("consume from queue")
+                            .consume("test_queue")
+                            .timeout(5000L)
+                            .check(
+                                    bodyString().exists()
+                            )
+            );
+
+    {
+        setUp(
+                scn.injectOpen(atOnceUsers(1))
+        )
+                .protocols(amqpConf)
+                .maxDuration(60);
+    }
+}


### PR DESCRIPTION
## Summary
- Add missing `bytesMessage()` overloads to `PublishDslBuilderMessage.java` — the Scala DSL had both `bytesMessage(byte[])` and `bytesMessage(String)` (EL expression) but the Java wrapper only exposed `textMessage()`
- Remove deprecated `noReplyTo()` from both Java and Scala sides — it had no runtime effect (the `setReplyTo` field was never consumed by the `RequestReply` action) and was already marked `@deprecated` in Scala
- Add `ConsumeExample.java` to cover the consume flow, which was the only major scenario missing from Java examples

## Test plan
- [x] `sbt clean compile test` passes (133 tests, 0 failures)
- [x] `sbt scalafmtAll scalafmtSbt` produces no changes
- [x] Verified `noReplyTo`/`setReplyTo` have zero remaining references
- [x] New `ConsumeExample.java` compiles alongside existing Java examples

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)