### PR TITLE
chore: modernize dependencies and CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v7
       - name: Scalafmt Check
         run: sbt scalafmtCheckAll scalafmtSbtCheck
 
@@ -47,9 +47,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
 
   test:
     name: Test (Java ${{ matrix.java }})
@@ -63,7 +63,7 @@ jobs:
         java: ['17', '21']
     services:
       rabbitmq:
-        image: rabbitmq:3.13.7-management-alpine
+        image: rabbitmq:4.1.8-management-alpine
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -75,20 +75,20 @@ jobs:
           --health-cmd "rabbitmq-diagnostics -q ping" --health-interval 5s --health-timeout 5s --health-retries 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Java (Temurin ${{ matrix.java }})
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v7
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
@@ -104,7 +104,7 @@ jobs:
         run: sbt "Gatling / testOnly org.galaxio.gatling.amqp.examples.AmqpGatlingTest"
       - name: Upload coverage reports to Codecov
         if: matrix.java == '17'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
 
@@ -117,7 +117,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Compute next version & create tag
@@ -187,11 +187,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Java (Temurin 17) with sbt cache
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -199,9 +199,9 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v7
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
@@ -241,7 +241,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.changelog }}
         env:

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload run summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: scala-steward-run-summary
           path: /home/runner/scala-steward/workspace/run-summary.md

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 runner.dialect = "scala213"
-version = 3.10.6
+version = 3.11.1
 binPack.parentConstructors = true
 maxColumn = 128
 includeCurlyBraceInSelectChains = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ AMQP/RabbitMQ protocol plugin for Gatling. Published library — treat all publi
 Principal Engineer in software development and performance testing. Strong Scala, Java, Kotlin, Gatling plugin, and AMQP/RabbitMQ expertise. Prefer small, clear, backward-compatible changes unless the task explicitly requires otherwise.
 
 ## Stack
-- Scala 2.13, SBT, Gatling 3.13.5, Java 17+
+- Scala 2.13, SBT 1.12.11, Gatling 3.13.5, Java 17+
 - AMQP/RabbitMQ plugin: publish, request-reply, and consume flows
 - Java API facade with Kotlin-compatible usage and tests
 - RabbitMQ Java client, Testcontainers RabbitMQ, Codecov, Sonatype

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,6 @@
-version: "3"
-
 services:
   rabbit1:
-    image: rabbitmq:3.13.7-management
+    image: rabbitmq:4.1.8-management
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 5s
@@ -12,7 +10,7 @@ services:
     - 5672:5672
     - 15672:15672
   rabbit2:
-    image: rabbitmq:3.13.7-management
+    image: rabbitmq:4.1.8-management
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 5s

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,11 +13,11 @@ object Dependencies {
     "io.gatling"            % "gatling-test-framework"    % gatlingVersion % "it,test",
   )
 
-  lazy val rabbitmq    = "com.rabbitmq"       % "amqp-client"   % "5.30.0"
+  lazy val rabbitmq    = "com.rabbitmq"       % "amqp-client"   % "5.31.0"
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.13.1"
   lazy val fastUUID    = "com.eatthepath"     % "fast-uuid"     % "0.2.0"
 
-  lazy val scalaTest               = "org.scalatest" %% "scalatest"                      % "3.2.19" % Test
+  lazy val scalaTest               = "org.scalatest" %% "scalatest"                      % "3.2.20" % Test
   lazy val testcontainersScalatest = "com.dimafeng"  %% "testcontainers-scala-scalatest" % "0.44.1" % Test
   lazy val testcontainersRabbitmq  = "com.dimafeng"  %% "testcontainers-scala-rabbitmq"  % "0.44.1" % Test
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # suppress inspection "UnusedProperty"
-sbt.version=1.12.2
+sbt.version=1.12.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
-addSbtPlugin("io.gatling"     % "gatling-sbt"    % "4.18.0")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.6")
+addSbtPlugin("io.gatling"     % "gatling-sbt"    % "4.18.3")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.6.1")
 addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.4.4")


### PR DESCRIPTION
## Summary

- Bump sbt 1.12.2 → 1.12.11 (includes security fix CVE-2026-32948)
- Bump amqp-client 5.30.0 → 5.31.0, ScalaTest 3.2.19 → 3.2.20
- Bump gatling-sbt 4.18.0 → 4.18.3, sbt-scalafmt 2.5.6 → 2.6.1, scalafmt 3.10.6 → 3.11.1
- Upgrade RabbitMQ Docker from EOL 3.13.7 to 4.1.8 (remove deprecated `version: "3"`)
- Bump all GitHub Actions to latest major: checkout v6, setup-java v5, cache v5, dependency-review-action v5, codecov-action v5, upload-artifact v5, coursier/cache-action v7, action-gh-release v3

## Test plan

- [x] `sbt clean compile` — passes
- [x] `sbt test` — 141 tests pass (against RabbitMQ 4.1.8)
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` — passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)