### PR TITLE
docs: make AGENTS.md stack versions patch-agnostic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ AMQP/RabbitMQ protocol plugin for Gatling. Published library — treat all publi
 Principal Engineer in software development and performance testing. Strong Scala, Java, Kotlin, Gatling plugin, and AMQP/RabbitMQ expertise. Prefer small, clear, backward-compatible changes unless the task explicitly requires otherwise.
 
 ## Stack
-- Scala 2.13, SBT 1.12.11, Gatling 3.13.5, Java 17+
+- Scala 2.13.x, SBT 1.12.x, Gatling 3.13.x, Java 17+
 - AMQP/RabbitMQ plugin: publish, request-reply, and consume flows
 - Java API facade with Kotlin-compatible usage and tests
 - RabbitMQ Java client, Testcontainers RabbitMQ, Codecov, Sonatype


### PR DESCRIPTION
## What

The `## Stack` line in `AGENTS.md` pinned exact patch versions, so it went stale on every scala-steward bump — it read **SBT 1.12.11** against an actual `1.12.15` in `project/build.properties` (#72).

Patch releases are compatible here, so the exact patch number carries no information a reader of this file needs. Pinning it just guarantees the doc is wrong again after the next bump.

```diff
-- Scala 2.13, SBT 1.12.11, Gatling 3.13.5, Java 17+
+- Scala 2.13.x, SBT 1.12.x, Gatling 3.13.x, Java 17+
```

## Why each position

| Component | Written as | Actual | Source |
| --- | --- | --- | --- |
| Scala | `2.13.x` | `2.13.18` | `build.sbt` |
| SBT | `1.12.x` | `1.12.15` | `project/build.properties` |
| Gatling | `3.13.x` | `3.13.5` | `project/Dependencies.scala` |
| Java | `17+` | 17 and 21 in CI | `.github/workflows/ci.yml` matrix — a supported-version floor, not a pin, so unchanged |

The minor versions stay explicit because those *are* compatibility boundaries: 2.13 vs 3.x for Scala, and Gatling 3.13 vs an older minor, are real distinctions for anyone working in this repo.

The build files remain the source of truth for exact versions — the Repo Notes section already says so, so nothing there needed changing.

The amqp-client 5.34.0 bump (#65) needs no doc change: `AGENTS.md` refers to the "RabbitMQ Java client" without pinning a version.

Docs only; no build or source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)