### PR TITLE
chore: gitignore Metals and Bloop artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@
 /target/
 /.bsp
 /results
+
+### IDE / build server artifacts (machine-local, auto-generated)
+/.bloop/
+/project/.bloop/
+/.metals/
+/project/metals.sbt
+/.mcp.json


### PR DESCRIPTION
## What

Metals and the Bloop build server generate machine-local files in the working tree. They were not covered by `.gitignore`, so `git status` showed ~15k lines of untracked noise on every checkout:

| Path | Contents | Why it can't be committed |
| --- | --- | --- |
| `.bloop/`, `project/.bloop/` | ~480 KB of JSON | Absolute paths (`/Users/<name>/…`) — meaningless on any other machine |
| `.metals/` | H2 workspace DB, logs, lock files | Local session state; `metals.mv.db` alone is a binary blob |
| `project/metals.sbt` | `addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % …)` | Header says `DO NOT EDIT! This file is auto-generated`; committing it forces sbt-bloop onto CI and every contributor, and it drifts with the Metals version |
| `.mcp.json` | Metals MCP endpoint | Points at `http://localhost:<port>/mcp` with a port that changes on every Metals restart |

Everything here is regenerated by `sbt bloopInstall` or by reopening the project in Metals, so nothing is lost.

## Notes

- None of these paths were tracked (`git ls-files` on them is empty), so no `git rm --cached` is required — the `.gitignore` entries are sufficient.
- `*.log` and `/.bsp` were already covered; this only adds paths that were not.
- `.mcp.json` is normally the *shared* project MCP config, but the one this repo generates is Metals-local with an ephemeral port, so it is ignored deliberately. If a team-wide MCP config is ever wanted, this entry is the thing to revisit.
- No build or source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)