### PR TITLE
chore: tell Scala Steward to skip Gatling 3.15

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,15 @@
+# Scala Steward repo configuration
+# Docs: https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+
+# Gatling 3.15 is held back for now. PRs #59 and #60 (gatling-core /
+# gatling-charts-highcharts 3.13.5 -> 3.15.1) were closed deliberately; without
+# this rule Steward re-opens them on every run, since closing a PR does not
+# teach it to skip the version.
+#
+# Scoped by version prefix rather than by groupId alone, so 3.14.x, 3.16.x and
+# the io.gatling:gatling-sbt plugin (on a separate 4.x track) keep getting PRs.
+# Remove both entries when the 3.15 upgrade is picked up.
+updates.ignore = [
+  { groupId = "io.gatling", version = { prefix = "3.15." } },
+  { groupId = "io.gatling.highcharts", version = { prefix = "3.15." } }
+]


### PR DESCRIPTION
Closing #59 and #60 does not stop Scala Steward from re-proposing Gatling 3.15.1 — it re-opens the same PRs on the next scheduled run (Sundays, `.github/workflows/scala-steward.yml`). The repo had no `.scala-steward.conf` at all, so this adds one.

```hocon
updates.ignore = [
  { groupId = "io.gatling", version = { prefix = "3.15." } },
  { groupId = "io.gatling.highcharts", version = { prefix = "3.15." } }
]
```

Two entries because Gatling ships under two groupIds: `io.gatling` (gatling-core, gatling-core-java, gatling-test-framework) and `io.gatling.highcharts` (gatling-charts-highcharts).

Scoped by version prefix rather than by groupId alone, so this only blocks the 3.15 line — 3.14.x, 3.16.x, and the `io.gatling:gatling-sbt` plugin (separate 4.x track, currently 4.18.4) keep getting update PRs.

Verified the HOCON parses and yields exactly the two intended entries:

```
[Config(SimpleConfigObject({"groupId":"io.gatling","version":{"prefix":"3.15."}})),
 Config(SimpleConfigObject({"groupId":"io.gatling.highcharts","version":{"prefix":"3.15."}}))]
```

Remove both entries when the 3.15 upgrade is picked up.

Also for the record: the stale branches `update/gatling-core-3.15.1` (`dbf8124`) and `update/gatling-charts-highcharts-3.15.1` (`1dde6d0`) were deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)