### PR TITLE
fix: group Scala Steward bumps under Dependencies in release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -43,6 +43,9 @@ commit_parsers = [
   { message = "^perf", group = "<!-- 03 -->Performance" },
   { message = "^docs", group = "<!-- 04 -->Documentation" },
   { message = "^chore\\(deps\\)", group = "<!-- 05 -->Dependencies" },
+  # Scala Steward writes "Update <artifact> to <version>", which is not a Conventional
+  # Commit and would otherwise fall through to the catch-all and render under "Other".
+  { message = "^Update .+ to ", group = "<!-- 05 -->Dependencies" },
   { message = "^(refactor|test|ci|build|chore|style|revert)", group = "<!-- 06 -->Maintenance" },
   # Catch-all: a non-Conventional-Commit message still ships (e.g. an older or squash-merged commit)
   # instead of silently vanishing from the notes.


### PR DESCRIPTION
Follow-up to #76, which merged before this commit landed on the branch.

Scala Steward writes `Update <artifact> to <version>`, which is not a Conventional Commit. It fell through `cliff.toml`'s catch-all parser and rendered under **Other** instead of **Dependencies**.

Verified against real history — with the rule, the notes for the pending release resolve to five clean sections and no catch-all group:

```
### Features
### Fixes
### Documentation
### Dependencies
### Maintenance
```

Without it, the six Steward bumps (#64, #65, #66, #69, #71, #72) sit under **Other**.

Small deviation from kafka's `cliff.toml`, which has the same gap — worth proposing back to the sibling repos separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)